### PR TITLE
Peaks with p-value less than TauW are considered weak

### DIFF
--- a/Core/Model/Processor.cs
+++ b/Core/Model/Processor.cs
@@ -105,7 +105,7 @@ namespace Genometric.MSPC.Model
                         foreach (I p in strand.Value.Intervals)
                         {
                             if (cancel) return null;
-                            if (p.Value <= _config.TauW)
+                            if (p.Value < _config.TauW)
                                 _trees[sample.Key][chr.Key].Add(p);
                             else
                                 _analysisResults[sample.Key].R_j__b[chr.Key].Add(p);
@@ -126,7 +126,7 @@ namespace Genometric.MSPC.Model
                             // Initial assessment: classifying peak as strong or weak based on p-value.
                             if (peak.Value <= _config.TauS)
                                 _analysisResults[sample.Key].R_j__s[chr.Key].Add(peak);
-                            else if (peak.Value <= _config.TauW)
+                            else if (peak.Value < _config.TauW)
                                 _analysisResults[sample.Key].R_j__w[chr.Key].Add(peak);
                             else
                                 continue;


### PR DESCRIPTION
As it is described in [the MSPC manuscript](https://academic.oup.com/bioinformatics/article/31/17/2761/183989#) peaks are classified as the following: 

- Stringent peak: `p-value < TauS`
- Weak peak: `TauW < p-value <= TauS`
- Noise: `p-value >= TauW`  

However, it was implemented as the following: 

- Stringent peak: `p-value < TauS`
- Weak peak: `TauW <= p-value <= TauS` (`TauW` is inclusive, should have been exlusive)
- Noise: `p-value > TauW`  (`TauW` is exclusive, it should have been inclusive)

This PR fixes this issue.