### PR TITLE
Overhaul ProcessedPeak class

### DIFF
--- a/CLI/Export/ExporterBase.cs
+++ b/CLI/Export/ExporterBase.cs
@@ -44,10 +44,10 @@ namespace Genometric.MSPC.CLI.Exporter
                         {
                             writter.WriteLine(
                                 chr.Key + "\t" +
-                                item.Peak.Left.ToString() + "\t" +
-                                item.Peak.Right.ToString() + "\t" +
-                                item.Peak.Name + "\t" +
-                                ConvertPValue(item.Peak.Value) + "\t" +
+                                item.Source.Left.ToString() + "\t" +
+                                item.Source.Right.ToString() + "\t" +
+                                item.Source.Name + "\t" +
+                                ConvertPValue(item.Source.Value) + "\t" +
                                 Math.Round(item.XSquared, 3) + "\t" +
                                 ConvertPValue(item.RTP));
                         }
@@ -69,10 +69,10 @@ namespace Genometric.MSPC.CLI.Exporter
                         {
                             writter.WriteLine(
                                 chr.Key + "\t" +
-                                item.Peak.Left.ToString() + "\t" +
-                                item.Peak.Right.ToString() + "\t" +
-                                item.Peak.Name + "\t" +
-                                ConvertPValue(item.Peak.Value) + "\t" +
+                                item.Source.Left.ToString() + "\t" +
+                                item.Source.Right.ToString() + "\t" +
+                                item.Source.Name + "\t" +
+                                ConvertPValue(item.Source.Value) + "\t" +
                                 Math.Round(item.XSquared, 3) + "\t" +
                                 ConvertPValue(item.RTP));
                         }
@@ -94,10 +94,10 @@ namespace Genometric.MSPC.CLI.Exporter
                         {
                             writter.WriteLine(
                                 chr.Key + "\t" +
-                                item.Peak.Left.ToString() + "\t" +
-                                item.Peak.Right.ToString() + "\t" +
-                                item.Peak.Name + "\t" +
-                                ConvertPValue(item.Peak.Value) + "\t" +
+                                item.Source.Left.ToString() + "\t" +
+                                item.Source.Right.ToString() + "\t" +
+                                item.Source.Name + "\t" +
+                                ConvertPValue(item.Source.Value) + "\t" +
                                 Math.Round(item.XSquared, 3) + "\t" +
                                 ConvertPValue(item.RTP));
                         }
@@ -120,10 +120,10 @@ namespace Genometric.MSPC.CLI.Exporter
                         {
                             writter.WriteLine(
                                 chr.Key + "\t" +
-                                item.Peak.Left.ToString() + "\t" +
-                                item.Peak.Right.ToString() + "\t" +
-                                item.Peak.Name + "\t" +
-                                ConvertPValue(item.Peak.Value) + "\t" +
+                                item.Source.Left.ToString() + "\t" +
+                                item.Source.Right.ToString() + "\t" +
+                                item.Source.Name + "\t" +
+                                ConvertPValue(item.Source.Value) + "\t" +
                                 Math.Round(item.XSquared, 3) + "\t" +
                                 ConvertPValue(item.RTP));
                         }
@@ -191,10 +191,10 @@ namespace Genometric.MSPC.CLI.Exporter
                     {
                         writter.WriteLine(
                             chr.Key + "\t" +
-                            item.Peak.Left.ToString() + "\t" +
-                            item.Peak.Right.ToString() + "\t" +
-                            item.Peak.Name + "\t" +
-                            ConvertPValue(item.Peak.Value) + "\t" +
+                            item.Source.Left.ToString() + "\t" +
+                            item.Source.Right.ToString() + "\t" +
+                            item.Source.Name + "\t" +
+                            ConvertPValue(item.Source.Value) + "\t" +
                             Math.Round(item.XSquared, 3) + "\t" +
                             ConvertPValue(item.RTP));
                     }
@@ -217,10 +217,10 @@ namespace Genometric.MSPC.CLI.Exporter
                         {
                             writter.WriteLine(
                                 chr.Key + "\t" +
-                                item.Peak.Left.ToString() + "\t" +
-                                item.Peak.Right.ToString() + "\t" +
-                                item.Peak.Name + "\t" +
-                                ConvertPValue(item.Peak.Value) + "\t" +
+                                item.Source.Left.ToString() + "\t" +
+                                item.Source.Right.ToString() + "\t" +
+                                item.Source.Name + "\t" +
+                                ConvertPValue(item.Source.Value) + "\t" +
                                 Math.Round(item.XSquared, 3) + "\t" +
                                 ConvertPValue(item.RTP));
                         }
@@ -244,10 +244,10 @@ namespace Genometric.MSPC.CLI.Exporter
                         {
                             writter.WriteLine(
                                 chr.Key + "\t" +
-                                item.Peak.Left.ToString() + "\t" +
-                                item.Peak.Right.ToString() + "\t" +
-                                item.Peak.Name + "\t" +
-                                ConvertPValue(item.Peak.Value) + "\t" +
+                                item.Source.Left.ToString() + "\t" +
+                                item.Source.Right.ToString() + "\t" +
+                                item.Source.Name + "\t" +
+                                ConvertPValue(item.Source.Value) + "\t" +
                                 Math.Round(item.XSquared, 3) + "\t" +
                                 ConvertPValue(item.RTP));
                         }
@@ -269,10 +269,10 @@ namespace Genometric.MSPC.CLI.Exporter
                     {
                         writter.WriteLine(
                             chr.Key + "\t" +
-                            item.Peak.Left.ToString() + "\t" +
-                            item.Peak.Right.ToString() + "\t" +
-                            item.Peak.Name + "\t" +
-                            ConvertPValue(item.Peak.Value) + "\t" +
+                            item.Source.Left.ToString() + "\t" +
+                            item.Source.Right.ToString() + "\t" +
+                            item.Source.Name + "\t" +
+                            ConvertPValue(item.Source.Value) + "\t" +
                             Math.Round(item.XSquared, 3));
                     }
                 }
@@ -292,10 +292,10 @@ namespace Genometric.MSPC.CLI.Exporter
                         {
                             writter.WriteLine(
                                 chr.Key + "\t" +
-                                item.Peak.Left.ToString() + "\t" +
-                                item.Peak.Right.ToString() + "\t" +
-                                item.Peak.Name + "\t" +
-                                ConvertPValue(item.Peak.Value) + "\t" +
+                                item.Source.Left.ToString() + "\t" +
+                                item.Source.Right.ToString() + "\t" +
+                                item.Source.Name + "\t" +
+                                ConvertPValue(item.Source.Value) + "\t" +
                                 Math.Round(item.XSquared, 3));
                         }
                     }
@@ -316,10 +316,10 @@ namespace Genometric.MSPC.CLI.Exporter
                         {
                             writter.WriteLine(
                                 chr.Key + "\t" +
-                                item.Peak.Left.ToString() + "\t" +
-                                item.Peak.Right.ToString() + "\t" +
-                                item.Peak.Name + "\t" +
-                                ConvertPValue(item.Peak.Value) + "\t" +
+                                item.Source.Left.ToString() + "\t" +
+                                item.Source.Right.ToString() + "\t" +
+                                item.Source.Name + "\t" +
+                                ConvertPValue(item.Source.Value) + "\t" +
                                 Math.Round(item.XSquared, 3));
                         }
                     }

--- a/CLI/Export/ExporterBase.cs
+++ b/CLI/Export/ExporterBase.cs
@@ -40,16 +40,16 @@ namespace Genometric.MSPC.CLI.Exporter
                 {
                     foreach (var item in chr.Value.Get(Attributes.Output))
                     {
-                        if (item.statisticalClassification == Attributes.TruePositive)
+                        if (item.StatisticalClassification == Attributes.TruePositive)
                         {
                             writter.WriteLine(
                                 chr.Key + "\t" +
-                                item.peak.Left.ToString() + "\t" +
-                                item.peak.Right.ToString() + "\t" +
-                                item.peak.Name + "\t" +
-                                ConvertPValue(item.peak.Value) + "\t" +
-                                Math.Round(item.xSquared, 3) + "\t" +
-                                ConvertPValue(item.rtp));
+                                item.Peak.Left.ToString() + "\t" +
+                                item.Peak.Right.ToString() + "\t" +
+                                item.Peak.Name + "\t" +
+                                ConvertPValue(item.Peak.Value) + "\t" +
+                                Math.Round(item.XSquared, 3) + "\t" +
+                                ConvertPValue(item.RTP));
                         }
                     }
                 }
@@ -65,16 +65,16 @@ namespace Genometric.MSPC.CLI.Exporter
                 {
                     foreach (var item in chr.Value.Get(Attributes.Output))
                     {
-                        if (item.statisticalClassification == Attributes.TruePositive && item.classification.Contains(Attributes.StringentConfirmed))
+                        if (item.StatisticalClassification == Attributes.TruePositive && item.Classification.Contains(Attributes.StringentConfirmed))
                         {
                             writter.WriteLine(
                                 chr.Key + "\t" +
-                                item.peak.Left.ToString() + "\t" +
-                                item.peak.Right.ToString() + "\t" +
-                                item.peak.Name + "\t" +
-                                ConvertPValue(item.peak.Value) + "\t" +
-                                Math.Round(item.xSquared, 3) + "\t" +
-                                ConvertPValue(item.rtp));
+                                item.Peak.Left.ToString() + "\t" +
+                                item.Peak.Right.ToString() + "\t" +
+                                item.Peak.Name + "\t" +
+                                ConvertPValue(item.Peak.Value) + "\t" +
+                                Math.Round(item.XSquared, 3) + "\t" +
+                                ConvertPValue(item.RTP));
                         }
                     }
                 }
@@ -90,16 +90,16 @@ namespace Genometric.MSPC.CLI.Exporter
                 {
                     foreach (var item in chr.Value.Get(Attributes.Output))
                     {
-                        if (item.statisticalClassification == Attributes.TruePositive && item.classification.Contains(Attributes.WeakConfirmed))
+                        if (item.StatisticalClassification == Attributes.TruePositive && item.Classification.Contains(Attributes.WeakConfirmed))
                         {
                             writter.WriteLine(
                                 chr.Key + "\t" +
-                                item.peak.Left.ToString() + "\t" +
-                                item.peak.Right.ToString() + "\t" +
-                                item.peak.Name + "\t" +
-                                ConvertPValue(item.peak.Value) + "\t" +
-                                Math.Round(item.xSquared, 3) + "\t" +
-                                ConvertPValue(item.rtp));
+                                item.Peak.Left.ToString() + "\t" +
+                                item.Peak.Right.ToString() + "\t" +
+                                item.Peak.Name + "\t" +
+                                ConvertPValue(item.Peak.Value) + "\t" +
+                                Math.Round(item.XSquared, 3) + "\t" +
+                                ConvertPValue(item.RTP));
                         }
                     }
                 }
@@ -116,16 +116,16 @@ namespace Genometric.MSPC.CLI.Exporter
                 {
                     foreach (var item in chr.Value.Get(Attributes.Output))
                     {
-                        if (item.statisticalClassification == Attributes.FalsePositive)
+                        if (item.StatisticalClassification == Attributes.FalsePositive)
                         {
                             writter.WriteLine(
                                 chr.Key + "\t" +
-                                item.peak.Left.ToString() + "\t" +
-                                item.peak.Right.ToString() + "\t" +
-                                item.peak.Name + "\t" +
-                                ConvertPValue(item.peak.Value) + "\t" +
-                                Math.Round(item.xSquared, 3) + "\t" +
-                                ConvertPValue(item.rtp));
+                                item.Peak.Left.ToString() + "\t" +
+                                item.Peak.Right.ToString() + "\t" +
+                                item.Peak.Name + "\t" +
+                                ConvertPValue(item.Peak.Value) + "\t" +
+                                Math.Round(item.XSquared, 3) + "\t" +
+                                ConvertPValue(item.RTP));
                         }
                     }
                 }
@@ -191,12 +191,12 @@ namespace Genometric.MSPC.CLI.Exporter
                     {
                         writter.WriteLine(
                             chr.Key + "\t" +
-                            item.peak.Left.ToString() + "\t" +
-                            item.peak.Right.ToString() + "\t" +
-                            item.peak.Name + "\t" +
-                            ConvertPValue(item.peak.Value) + "\t" +
-                            Math.Round(item.xSquared, 3) + "\t" +
-                            ConvertPValue(item.rtp));
+                            item.Peak.Left.ToString() + "\t" +
+                            item.Peak.Right.ToString() + "\t" +
+                            item.Peak.Name + "\t" +
+                            ConvertPValue(item.Peak.Value) + "\t" +
+                            Math.Round(item.XSquared, 3) + "\t" +
+                            ConvertPValue(item.RTP));
                     }
                 }
             }
@@ -213,16 +213,16 @@ namespace Genometric.MSPC.CLI.Exporter
 
                     foreach (var item in sortedDictionary)
                     {
-                        if (item.classification.Contains(Attributes.StringentConfirmed))
+                        if (item.Classification.Contains(Attributes.StringentConfirmed))
                         {
                             writter.WriteLine(
                                 chr.Key + "\t" +
-                                item.peak.Left.ToString() + "\t" +
-                                item.peak.Right.ToString() + "\t" +
-                                item.peak.Name + "\t" +
-                                ConvertPValue(item.peak.Value) + "\t" +
-                                Math.Round(item.xSquared, 3) + "\t" +
-                                ConvertPValue(item.rtp));
+                                item.Peak.Left.ToString() + "\t" +
+                                item.Peak.Right.ToString() + "\t" +
+                                item.Peak.Name + "\t" +
+                                ConvertPValue(item.Peak.Value) + "\t" +
+                                Math.Round(item.XSquared, 3) + "\t" +
+                                ConvertPValue(item.RTP));
                         }
                     }
                 }
@@ -240,16 +240,16 @@ namespace Genometric.MSPC.CLI.Exporter
 
                     foreach (var item in sortedDictionary)
                     {
-                        if (item.classification.Contains(Attributes.WeakConfirmed))
+                        if (item.Classification.Contains(Attributes.WeakConfirmed))
                         {
                             writter.WriteLine(
                                 chr.Key + "\t" +
-                                item.peak.Left.ToString() + "\t" +
-                                item.peak.Right.ToString() + "\t" +
-                                item.peak.Name + "\t" +
-                                ConvertPValue(item.peak.Value) + "\t" +
-                                Math.Round(item.xSquared, 3) + "\t" +
-                                ConvertPValue(item.rtp));
+                                item.Peak.Left.ToString() + "\t" +
+                                item.Peak.Right.ToString() + "\t" +
+                                item.Peak.Name + "\t" +
+                                ConvertPValue(item.Peak.Value) + "\t" +
+                                Math.Round(item.XSquared, 3) + "\t" +
+                                ConvertPValue(item.RTP));
                         }
                     }
                 }
@@ -269,11 +269,11 @@ namespace Genometric.MSPC.CLI.Exporter
                     {
                         writter.WriteLine(
                             chr.Key + "\t" +
-                            item.peak.Left.ToString() + "\t" +
-                            item.peak.Right.ToString() + "\t" +
-                            item.peak.Name + "\t" +
-                            ConvertPValue(item.peak.Value) + "\t" +
-                            Math.Round(item.xSquared, 3));
+                            item.Peak.Left.ToString() + "\t" +
+                            item.Peak.Right.ToString() + "\t" +
+                            item.Peak.Name + "\t" +
+                            ConvertPValue(item.Peak.Value) + "\t" +
+                            Math.Round(item.XSquared, 3));
                     }
                 }
             }
@@ -288,15 +288,15 @@ namespace Genometric.MSPC.CLI.Exporter
                 {
                     foreach (var item in chr.Value.Get(Attributes.Discarded))
                     {
-                        if (item.classification.Contains(Attributes.StringentDiscarded))
+                        if (item.Classification.Contains(Attributes.StringentDiscarded))
                         {
                             writter.WriteLine(
                                 chr.Key + "\t" +
-                                item.peak.Left.ToString() + "\t" +
-                                item.peak.Right.ToString() + "\t" +
-                                item.peak.Name + "\t" +
-                                ConvertPValue(item.peak.Value) + "\t" +
-                                Math.Round(item.xSquared, 3));
+                                item.Peak.Left.ToString() + "\t" +
+                                item.Peak.Right.ToString() + "\t" +
+                                item.Peak.Name + "\t" +
+                                ConvertPValue(item.Peak.Value) + "\t" +
+                                Math.Round(item.XSquared, 3));
                         }
                     }
                 }
@@ -312,15 +312,15 @@ namespace Genometric.MSPC.CLI.Exporter
                 {
                     foreach (var item in chr.Value.Get(Attributes.Discarded))
                     {
-                        if (item.classification.Contains(Attributes.WeakDiscarded))
+                        if (item.Classification.Contains(Attributes.WeakDiscarded))
                         {
                             writter.WriteLine(
                                 chr.Key + "\t" +
-                                item.peak.Left.ToString() + "\t" +
-                                item.peak.Right.ToString() + "\t" +
-                                item.peak.Name + "\t" +
-                                ConvertPValue(item.peak.Value) + "\t" +
-                                Math.Round(item.xSquared, 3));
+                                item.Peak.Left.ToString() + "\t" +
+                                item.Peak.Right.ToString() + "\t" +
+                                item.Peak.Name + "\t" +
+                                ConvertPValue(item.Peak.Value) + "\t" +
+                                Math.Round(item.XSquared, 3));
                         }
                     }
                 }

--- a/CLI/Export/ExporterBase.cs
+++ b/CLI/Export/ExporterBase.cs
@@ -40,7 +40,7 @@ namespace Genometric.MSPC.CLI.Exporter
                 {
                     foreach (var item in chr.Value.Get(Attributes.Output))
                     {
-                        if (item.StatisticalClassification == Attributes.TruePositive)
+                        if (item.Classification.Contains(Attributes.TruePositive))
                         {
                             writter.WriteLine(
                                 chr.Key + "\t" +
@@ -65,7 +65,7 @@ namespace Genometric.MSPC.CLI.Exporter
                 {
                     foreach (var item in chr.Value.Get(Attributes.Output))
                     {
-                        if (item.StatisticalClassification == Attributes.TruePositive && item.Classification.Contains(Attributes.StringentConfirmed))
+                        if (item.Classification.Contains(Attributes.TruePositive) && item.Classification.Contains(Attributes.StringentConfirmed))
                         {
                             writter.WriteLine(
                                 chr.Key + "\t" +
@@ -90,7 +90,7 @@ namespace Genometric.MSPC.CLI.Exporter
                 {
                     foreach (var item in chr.Value.Get(Attributes.Output))
                     {
-                        if (item.StatisticalClassification == Attributes.TruePositive && item.Classification.Contains(Attributes.WeakConfirmed))
+                        if (item.Classification.Contains(Attributes.TruePositive) && item.Classification.Contains(Attributes.WeakConfirmed))
                         {
                             writter.WriteLine(
                                 chr.Key + "\t" +
@@ -116,7 +116,7 @@ namespace Genometric.MSPC.CLI.Exporter
                 {
                     foreach (var item in chr.Value.Get(Attributes.Output))
                     {
-                        if (item.StatisticalClassification == Attributes.FalsePositive)
+                        if (item.Classification.Contains(Attributes.FalsePositive))
                         {
                             writter.WriteLine(
                                 chr.Key + "\t" +

--- a/Core.Tests/Classification/StringentConfirmed.cs
+++ b/Core.Tests/Classification/StringentConfirmed.cs
@@ -59,7 +59,7 @@ namespace Core.Tests.Base
                 Assert.True(s.Value.Chromosomes["chr1"].Get(Attributes.Confirmed).Count == 1);
             foreach (var s in res)
                 foreach (var p in s.Value.Chromosomes["chr1"].Get(Attributes.Confirmed))
-                    Assert.True(p.classification.Contains(Attributes.StringentConfirmed));
+                    Assert.True(p.Classification.Contains(Attributes.StringentConfirmed));
         }
     }
 }

--- a/Core.Tests/Classification/StringentDiscarded.cs
+++ b/Core.Tests/Classification/StringentDiscarded.cs
@@ -59,7 +59,7 @@ namespace Core.Tests.Base
                 Assert.True(s.Value.Chromosomes["chr1"].Get(Attributes.Discarded).Count == 1);
             foreach (var s in res)
                 foreach (var p in s.Value.Chromosomes["chr1"].Get(Attributes.Confirmed))
-                    Assert.True(p.classification.Contains(Attributes.StringentDiscarded));
+                    Assert.True(p.Classification.Contains(Attributes.StringentDiscarded));
         }
     }
 }

--- a/Core.Tests/Classification/WeakConfirmed.cs
+++ b/Core.Tests/Classification/WeakConfirmed.cs
@@ -59,7 +59,7 @@ namespace Core.Tests.Base
                 Assert.True(s.Value.Chromosomes["chr1"].Get(Attributes.Confirmed).Count == 1);
             foreach (var s in res)
                 foreach (var p in s.Value.Chromosomes["chr1"].Get(Attributes.Confirmed))
-                    Assert.True(p.classification.Contains(Attributes.WeakConfirmed));
+                    Assert.True(p.Classification.Contains(Attributes.WeakConfirmed));
         }
     }
 }

--- a/Core.Tests/Classification/WeakDiscarded.cs
+++ b/Core.Tests/Classification/WeakDiscarded.cs
@@ -59,7 +59,7 @@ namespace Core.Tests.Base
                 Assert.True(s.Value.Chromosomes["chr1"].Get(Attributes.Discarded).Count == 1);
             foreach (var s in res)
                 foreach (var p in s.Value.Chromosomes["chr1"].Get(Attributes.Discarded))
-                    Assert.True(p.classification.Contains(Attributes.WeakDiscardedT));
+                    Assert.True(p.Classification.Contains(Attributes.WeakDiscardedT));
         }
     }
 }

--- a/Core.Tests/Example/Eg1.cs
+++ b/Core.Tests/Example/Eg1.cs
@@ -61,49 +61,49 @@ namespace Core.Tests.Example
 
             // Assert
             var s1 = res[0];
-            var qres = s1.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.peak.CompareTo(r11) == 0);
+            var qres = s1.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Peak.CompareTo(r11) == 0);
             Assert.True(qres != null);
-            Assert.True(qres.classification.Contains(Attributes.WeakConfirmed));
+            Assert.True(qres.Classification.Contains(Attributes.WeakConfirmed));
 
-            qres = s1.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.peak.CompareTo(r11) == 0);
+            qres = s1.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Peak.CompareTo(r11) == 0);
             Assert.True(qres == null);
 
-            qres = s1.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.peak.CompareTo(r12) == 0);
+            qres = s1.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Peak.CompareTo(r12) == 0);
             Assert.True(qres != null);
-            Assert.True(qres.classification.Contains(Attributes.StringentDiscardedC));
+            Assert.True(qres.Classification.Contains(Attributes.StringentDiscardedC));
 
-            qres = s1.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.peak.CompareTo(r12) == 0);
+            qres = s1.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Peak.CompareTo(r12) == 0);
             Assert.True(qres == null);
 
 
             var s2 = res[1];
-            qres = s2.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.peak.CompareTo(r21) == 0);
+            qres = s2.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Peak.CompareTo(r21) == 0);
             Assert.True(qres == null);
 
-            qres = s2.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.peak.CompareTo(r22) == 0);
+            qres = s2.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Peak.CompareTo(r22) == 0);
             Assert.True(qres != null);
-            Assert.True(qres.classification.Contains(Attributes.WeakDiscardedC));
+            Assert.True(qres.Classification.Contains(Attributes.WeakDiscardedC));
 
-            qres = s2.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.peak.CompareTo(r23) == 0);
+            qres = s2.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Peak.CompareTo(r23) == 0);
             Assert.True(qres != null);
-            Assert.True(qres.classification.Contains(Attributes.WeakDiscardedC));
+            Assert.True(qres.Classification.Contains(Attributes.WeakDiscardedC));
 
-            qres = s2.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.peak.CompareTo(r21) == 0);
+            qres = s2.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Peak.CompareTo(r21) == 0);
             Assert.True(qres != null);
-            Assert.True(qres.classification.Contains(Attributes.WeakConfirmed));
+            Assert.True(qres.Classification.Contains(Attributes.WeakConfirmed));
             // TODO: check for the count of stringent discarded and stringent confirmed.
 
             var s3 = res[2];
-            qres = s3.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.peak.CompareTo(r23) == 0);
+            qres = s3.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Peak.CompareTo(r23) == 0);
             Assert.True(qres == null);
 
-            qres = s3.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.peak.CompareTo(r33) == 0);
+            qres = s3.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Peak.CompareTo(r33) == 0);
             Assert.True(qres != null);
-            Assert.True(qres.classification.Contains(Attributes.StringentDiscardedC));
+            Assert.True(qres.Classification.Contains(Attributes.StringentDiscardedC));
 
-            qres = s3.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.peak.CompareTo(r32) == 0);
+            qres = s3.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Peak.CompareTo(r32) == 0);
             Assert.True(qres != null);
-            Assert.True(qres.classification.Contains(Attributes.StringentConfirmed));
+            Assert.True(qres.Classification.Contains(Attributes.StringentConfirmed));
 
             Assert.True(s1.Chromosomes["chr1"].Get(Attributes.Output).Count == 1);
             Assert.True(s2.Chromosomes["chr1"].Get(Attributes.Output).Count == 1);
@@ -128,43 +128,43 @@ namespace Core.Tests.Example
             var s1 = res[0];
             Assert.True(s1.Chromosomes["chr1"].Get(Attributes.Discarded).Count == 0);
 
-            var qres = s1.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.peak.CompareTo(r11) == 0);
+            var qres = s1.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Peak.CompareTo(r11) == 0);
             Assert.True(qres != null);
-            Assert.True(qres.classification.Contains(Attributes.WeakConfirmed));
+            Assert.True(qres.Classification.Contains(Attributes.WeakConfirmed));
 
-            qres = s1.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.peak.CompareTo(r12) == 0);
+            qres = s1.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Peak.CompareTo(r12) == 0);
             Assert.True(qres != null);
-            Assert.True(qres.classification.Contains(Attributes.StringentConfirmed));
+            Assert.True(qres.Classification.Contains(Attributes.StringentConfirmed));
 
 
             var s2 = res[1];
-            qres = s2.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.peak.CompareTo(r23) == 0);
+            qres = s2.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Peak.CompareTo(r23) == 0);
             Assert.True(qres != null);
-            Assert.True(qres.classification.Contains(Attributes.WeakDiscardedC));
+            Assert.True(qres.Classification.Contains(Attributes.WeakDiscardedC));
 
-            qres = s2.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.peak.CompareTo(r21) == 0);
+            qres = s2.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Peak.CompareTo(r21) == 0);
             Assert.True(qres != null);
-            Assert.True(qres.classification.Contains(Attributes.WeakConfirmed));
+            Assert.True(qres.Classification.Contains(Attributes.WeakConfirmed));
 
-            qres = s2.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.peak.CompareTo(r22) == 0);
+            qres = s2.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Peak.CompareTo(r22) == 0);
             Assert.True(qres != null);
-            Assert.True(qres.classification.Contains(Attributes.WeakConfirmed));
+            Assert.True(qres.Classification.Contains(Attributes.WeakConfirmed));
             // TODO: check for the count of stringent discarded and stringent confirmed.
 
             var s3 = res[2];
             /// Assert.True(s3.total__wdc + s3.total__wdt == 0);
 
-            qres = s3.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.peak.CompareTo(r31) == 0);
+            qres = s3.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Peak.CompareTo(r31) == 0);
             Assert.True(qres != null);
-            Assert.True(qres.classification.Contains(Attributes.WeakConfirmed));
+            Assert.True(qres.Classification.Contains(Attributes.WeakConfirmed));
 
-            qres = s3.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.peak.CompareTo(r33) == 0);
+            qres = s3.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Peak.CompareTo(r33) == 0);
             Assert.True(qres != null);
-            Assert.True(qres.classification.Contains(Attributes.StringentDiscardedC));
+            Assert.True(qres.Classification.Contains(Attributes.StringentDiscardedC));
 
-            qres = s3.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.peak.CompareTo(r32) == 0);
+            qres = s3.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Peak.CompareTo(r32) == 0);
             Assert.True(qres != null);
-            Assert.True(qres.classification.Contains(Attributes.StringentConfirmed));
+            Assert.True(qres.Classification.Contains(Attributes.StringentConfirmed));
 
             Assert.True(s1.Chromosomes["chr1"].Get(Attributes.Output).Count == 2);
             Assert.True(s2.Chromosomes["chr1"].Get(Attributes.Output).Count == 2);

--- a/Core.Tests/Example/Eg1.cs
+++ b/Core.Tests/Example/Eg1.cs
@@ -61,53 +61,53 @@ namespace Core.Tests.Example
 
             // Assert
             var s1 = res[0];
-            var qres = s1.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Peak.CompareTo(r11) == 0);
+            var qres = s1.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Source.CompareTo(r11) == 0);
             Assert.True(qres != null);
             Assert.True(qres.Classification.Contains(Attributes.WeakConfirmed));
 
-            qres = s1.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Peak.CompareTo(r11) == 0);
+            qres = s1.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Source.CompareTo(r11) == 0);
             Assert.True(qres == null);
 
-            qres = s1.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Peak.CompareTo(r12) == 0);
+            qres = s1.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Source.CompareTo(r12) == 0);
             Assert.True(qres != null);
             Assert.True(qres.Classification.Contains(Attributes.StringentDiscardedC));
 
-            qres = s1.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Peak.CompareTo(r12) == 0);
+            qres = s1.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Source.CompareTo(r12) == 0);
             Assert.True(qres == null);
 
 
             var s2 = res[1];
-            qres = s2.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Peak.CompareTo(r21) == 0);
+            qres = s2.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Source.CompareTo(r21) == 0);
             Assert.True(qres == null);
 
-            qres = s2.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Peak.CompareTo(r22) == 0);
+            qres = s2.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Source.CompareTo(r22) == 0);
             Assert.True(qres != null);
             Assert.True(qres.Classification.Contains(Attributes.WeakDiscardedC));
 
-            qres = s2.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Peak.CompareTo(r23) == 0);
+            qres = s2.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Source.CompareTo(r23) == 0);
             Assert.True(qres != null);
             Assert.True(qres.Classification.Contains(Attributes.WeakDiscardedC));
 
-            qres = s2.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Peak.CompareTo(r21) == 0);
+            qres = s2.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Source.CompareTo(r21) == 0);
             Assert.True(qres != null);
             Assert.True(qres.Classification.Contains(Attributes.WeakConfirmed));
             // TODO: check for the count of stringent discarded and stringent confirmed.
 
             var s3 = res[2];
-            qres = s3.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Peak.CompareTo(r23) == 0);
+            qres = s3.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Source.CompareTo(r23) == 0);
             Assert.True(qres == null);
 
-            qres = s3.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Peak.CompareTo(r33) == 0);
+            qres = s3.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Source.CompareTo(r33) == 0);
             Assert.True(qres != null);
             Assert.True(qres.Classification.Contains(Attributes.StringentDiscardedC));
 
-            qres = s3.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Peak.CompareTo(r32) == 0);
+            qres = s3.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Source.CompareTo(r32) == 0);
             Assert.True(qres != null);
             Assert.True(qres.Classification.Contains(Attributes.StringentConfirmed));
 
             Assert.True(s1.Chromosomes["chr1"].Get(Attributes.Output).Count == 1);
             Assert.True(s2.Chromosomes["chr1"].Get(Attributes.Output).Count == 1);
-            //Assert.True(s3.Chromosomes["chr1"].Get(new Attributes[] { Attributes.Output }).FirstOrDefault(x => x.peak.CompareTo(r32) == 0) != null);
+            //Assert.True(s3.Chromosomes["chr1"].Get(new Attributes[] { Attributes.Output }).FirstOrDefault(x => x.Source.CompareTo(r32) == 0) != null);
         }
 
         [Fact]
@@ -128,25 +128,25 @@ namespace Core.Tests.Example
             var s1 = res[0];
             Assert.True(s1.Chromosomes["chr1"].Get(Attributes.Discarded).Count == 0);
 
-            var qres = s1.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Peak.CompareTo(r11) == 0);
+            var qres = s1.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Source.CompareTo(r11) == 0);
             Assert.True(qres != null);
             Assert.True(qres.Classification.Contains(Attributes.WeakConfirmed));
 
-            qres = s1.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Peak.CompareTo(r12) == 0);
+            qres = s1.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Source.CompareTo(r12) == 0);
             Assert.True(qres != null);
             Assert.True(qres.Classification.Contains(Attributes.StringentConfirmed));
 
 
             var s2 = res[1];
-            qres = s2.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Peak.CompareTo(r23) == 0);
+            qres = s2.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Source.CompareTo(r23) == 0);
             Assert.True(qres != null);
             Assert.True(qres.Classification.Contains(Attributes.WeakDiscardedC));
 
-            qres = s2.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Peak.CompareTo(r21) == 0);
+            qres = s2.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Source.CompareTo(r21) == 0);
             Assert.True(qres != null);
             Assert.True(qres.Classification.Contains(Attributes.WeakConfirmed));
 
-            qres = s2.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Peak.CompareTo(r22) == 0);
+            qres = s2.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Source.CompareTo(r22) == 0);
             Assert.True(qres != null);
             Assert.True(qres.Classification.Contains(Attributes.WeakConfirmed));
             // TODO: check for the count of stringent discarded and stringent confirmed.
@@ -154,15 +154,15 @@ namespace Core.Tests.Example
             var s3 = res[2];
             /// Assert.True(s3.total__wdc + s3.total__wdt == 0);
 
-            qres = s3.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Peak.CompareTo(r31) == 0);
+            qres = s3.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Source.CompareTo(r31) == 0);
             Assert.True(qres != null);
             Assert.True(qres.Classification.Contains(Attributes.WeakConfirmed));
 
-            qres = s3.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Peak.CompareTo(r33) == 0);
+            qres = s3.Chromosomes["chr1"].Get(Attributes.Discarded).FirstOrDefault(x => x.Source.CompareTo(r33) == 0);
             Assert.True(qres != null);
             Assert.True(qres.Classification.Contains(Attributes.StringentDiscardedC));
 
-            qres = s3.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Peak.CompareTo(r32) == 0);
+            qres = s3.Chromosomes["chr1"].Get(Attributes.Confirmed).FirstOrDefault(x => x.Source.CompareTo(r32) == 0);
             Assert.True(qres != null);
             Assert.True(qres.Classification.Contains(Attributes.StringentConfirmed));
 

--- a/Core/Comparers/CompareByValue.cs
+++ b/Core/Comparers/CompareByValue.cs
@@ -22,12 +22,12 @@ namespace Genometric.MSPC.Comparers
                 if (B == null) return 1; // A is greater
                 else
                 {
-                    if (A.Peak.Value != B.Peak.Value)
-                        return A.Peak.Value.CompareTo(B.Peak.Value);
-                    else if (A.Peak.Left != B.Peak.Left)
-                        return A.Peak.Left.CompareTo(B.Peak.Left);
+                    if (A.Source.Value != B.Source.Value)
+                        return A.Source.Value.CompareTo(B.Source.Value);
+                    else if (A.Source.Left != B.Source.Left)
+                        return A.Source.Left.CompareTo(B.Source.Left);
                     else
-                        return A.Peak.Right.CompareTo(B.Peak.Right);
+                        return A.Source.Right.CompareTo(B.Source.Right);
                 }
             }
         }

--- a/Core/Comparers/CompareByValue.cs
+++ b/Core/Comparers/CompareByValue.cs
@@ -22,12 +22,12 @@ namespace Genometric.MSPC.Comparers
                 if (B == null) return 1; // A is greater
                 else
                 {
-                    if (A.peak.Value != B.peak.Value)
-                        return A.peak.Value.CompareTo(B.peak.Value);
-                    else if (A.peak.Left != B.peak.Left)
-                        return A.peak.Left.CompareTo(B.peak.Left);
+                    if (A.Peak.Value != B.Peak.Value)
+                        return A.Peak.Value.CompareTo(B.Peak.Value);
+                    else if (A.Peak.Left != B.Peak.Left)
+                        return A.Peak.Left.CompareTo(B.Peak.Left);
                     else
-                        return A.peak.Right.CompareTo(B.peak.Right);
+                        return A.Peak.Right.CompareTo(B.Peak.Right);
                 }
             }
         }

--- a/Core/Model/Messages.cs
+++ b/Core/Model/Messages.cs
@@ -1,20 +1,47 @@
-﻿using System;
+﻿/** Copyright © 2014-2015 Vahid Jalili
+ * 
+ * This file is part of MSPC project.
+ * MSPC is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * MSPC is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with Foobar. If not, see http://www.gnu.org/licenses/.
+ **/
+
 using System.Collections.Generic;
-using System.Text;
 
 namespace Genometric.MSPC.Core.Model
 {
     internal static class Messages
     {
-        public static string Decode(byte code)
+        public enum Codes : byte
+        {
+            /// <summary>
+            /// Default value; empty string.
+            /// </summary>
+            M000,
+
+            /// <summary>
+            /// X-squared is below chi-squared of Gamma.
+            /// </summary>
+            M001,
+
+            /// <summary>
+            /// Intersecting peaks count doesn't comply minimum C requirement.
+            /// </summary>
+            M002
+        }
+
+        public static string Decode(Codes code)
         {
             return _messages[code];
         }
 
-        private static Dictionary<byte, string> _messages = new Dictionary<byte, string>()
+        private static readonly Dictionary<Codes, string> _messages = new Dictionary<Codes, string>()
         {
-            { 0, "X-squared is below chi-squared of Gamma" },
-            { 1, "Intersecting peaks count doesn't comply minimum requirement" }
+            {Codes.M000, "" },
+            { Codes.M001, "X-squared is below chi-squared of Gamma." },
+            { Codes.M002, "Intersecting peaks count doesn't comply minimum C requirement." }
         };
     }
 }

--- a/Core/Model/Peak.cs
+++ b/Core/Model/Peak.cs
@@ -1,0 +1,94 @@
+﻿/** Copyright © 2014-2015 Vahid Jalili
+ * 
+ * This file is part of MSPC project.
+ * MSPC is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * MSPC is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with Foobar. If not, see http://www.gnu.org/licenses/.
+ **/
+
+using Genometric.GeUtilities.IGenomics;
+using System;
+using System.Collections.Generic;
+
+namespace Genometric.MSPC.Core.Model
+{
+    /// <summary>
+    /// A base type of MSPC-processed peak. 
+    /// </summary>
+    /// <typeparam name="I"></typeparam>
+    public class Peak<I> : IComparable<Peak<I>>
+            where I : IChIPSeqPeak, new()
+    {
+        public Peak(I source)
+        {
+            Source = source;
+        }
+
+        public I Source { private set; get; }
+
+        public int CompareTo(Peak<I> other)
+        {
+            if (other == null) return 1;
+
+            int c = Source.Left.CompareTo(other.Source.Left);
+            if (c == 0) return 0;
+            c = Source.Right.CompareTo(other.Source.Right);
+            if (c == 0) return 0;
+            c = Source.Value.CompareTo(other.Source.Value);
+            if (c == 0) return 0;
+            return Source.HashKey.CompareTo(other.Source.HashKey);
+        }
+
+        public static bool operator >(Peak<I> operand1, Peak<I> operand2)
+        {
+            return operand1.Source.CompareTo(operand2.Source) == 1;
+        }
+
+        public static bool operator <(Peak<I> operand1, Peak<I> operand2)
+        {
+            return operand1.Source.CompareTo(operand2.Source) == -1;
+        }
+
+        public static bool operator >=(Peak<I> operand1, Peak<I> operand2)
+        {
+            return operand1.Source.CompareTo(operand2.Source) >= 0;
+        }
+
+        public static bool operator <=(Peak<I> operand1, Peak<I> operand2)
+        {
+            return operand1.Source.CompareTo(operand2.Source) <= 0;
+        }
+
+        public static bool operator ==(Peak<I> operand1, Peak<I> operand2)
+        {
+            if (operand1 is null)
+                return operand2 is null;
+            return operand1.Equals(operand2);
+        }
+
+        public static bool operator !=(Peak<I> operand1, Peak<I> operand2)
+        {
+            if (operand1 is null)
+                return operand2 is null;
+            return !operand1.Equals(operand2);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            return EqualityComparer<I>.Default.Equals(Source, (obj as Peak<I>).Source);
+        }
+
+        public override int GetHashCode()
+        {
+            return Source.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return Source.ToString();
+        }
+    }
+}

--- a/Core/Model/ProcessedPeak.cs
+++ b/Core/Model/ProcessedPeak.cs
@@ -18,8 +18,9 @@ namespace Genometric.MSPC.Core.Model
     public class ProcessedPeak<I> : IComparable<ProcessedPeak<I>>
             where I : IChIPSeqPeak, new()
     {
-        public ProcessedPeak()
+        public ProcessedPeak(I peak)
         {
+            Peak = peak;
             StatisticalClassification = Attributes.TruePositive;
             Classification = new HashSet<Attributes>();
         }
@@ -27,44 +28,44 @@ namespace Genometric.MSPC.Core.Model
         /// <summary>
         /// Sets and gets the Confirmed I. Is a reference to the original er in cached data.
         /// </summary>
-        public I Peak { set; get; }
+        public I Peak { private set; get; }
 
         /// <summary>
         /// Sets and gets X-squared of test
         /// </summary>
-        public double XSquared { set; get; }
+        public double XSquared { internal set; get; }
 
         /// <summary>
         /// Right tailed probability of x-squared.
         /// </summary>
-        public double RTP { set; get; }
+        public double RTP { internal set; get; }
 
         /// <summary>
         /// Sets and gets the set of peaks intersecting with confirmed er
         /// </summary>
-        public List<SupportingPeak<I>> SupportingPeaks { set; get; }
+        public List<SupportingPeak<I>> SupportingPeaks { internal set; get; }
 
         /// <summary>
         /// Sets and gets the reason of discarding the er. It points to an index of
         /// predefined messages.
         /// </summary>
-        public byte Reason { set; get; }
+        public byte Reason { internal set; get; }
 
         /// <summary>
         /// Sets and gets classification type. 
         /// </summary>
-        public HashSet<Attributes> Classification { set; get; }
+        public HashSet<Attributes> Classification { internal set; get; }
 
         /// <summary>
         /// Sets and gets adjusted p-value using the multiple testing correction method of choice.
         /// </summary>
-        public double AdjPValue { set; get; }
+        public double AdjPValue { internal set; get; }
 
         /// <summary>
         /// Set and gets whether the peaks is identified as false-positive or true-positive 
         /// based on multiple testing correction threshold. 
         /// </summary>
-        public Attributes StatisticalClassification { set; get; }
+        public Attributes StatisticalClassification { internal set; get; }
 
         /// <summary>
         /// Contains different classification types.

--- a/Core/Model/ProcessedPeak.cs
+++ b/Core/Model/ProcessedPeak.cs
@@ -32,8 +32,10 @@ namespace Genometric.MSPC.Core.Model
             RTP = ChiSquaredCache.ChiSqrdDistRTP(xSquared, 2 + (supportingPeaks.Count * 2));
             SupportingPeaks = supportingPeaks;
             _reason = reason;
-            StatisticalClassification = Attributes.TruePositive;
-            Classification = new HashSet<Attributes>();
+            Classification = new HashSet<Attributes>
+            {
+                Attributes.TruePositive
+            };
         }
 
         /// <summary>
@@ -74,12 +76,6 @@ namespace Genometric.MSPC.Core.Model
         public double AdjPValue { internal set; get; }
 
         /// <summary>
-        /// Set and gets whether the peaks is identified as false-positive or true-positive 
-        /// based on multiple testing correction threshold. 
-        /// </summary>
-        public Attributes StatisticalClassification { internal set; get; }
-
-        /// <summary>
         /// Contains different classification types.
         /// </summary>
         int IComparable<ProcessedPeak<I>>.CompareTo(ProcessedPeak<I> other)
@@ -87,6 +83,17 @@ namespace Genometric.MSPC.Core.Model
             if (other == null) return 1;
 
             return Peak.CompareTo(other.Peak);
+        }
+
+        internal void SetStatisticalClassification(Attributes attribute)
+        {
+            if (attribute != Attributes.TruePositive && attribute != Attributes.FalsePositive)
+                throw new ArgumentException(
+                    String.Format("Invalid attribute; accepted values are: {0} and {1}.",
+                    Attributes.TruePositive.ToString(), Attributes.FalsePositive.ToString()));
+
+            if (!Classification.Remove(attribute))
+                Classification.Add(attribute);
         }
     }
 }

--- a/Core/Model/ProcessedPeak.cs
+++ b/Core/Model/ProcessedPeak.cs
@@ -1,8 +1,17 @@
-﻿using Genometric.GeUtilities.IGenomics;
+﻿/** Copyright © 2014-2015 Vahid Jalili
+ * 
+ * This file is part of MSPC project.
+ * MSPC is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * MSPC is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with Foobar. If not, see http://www.gnu.org/licenses/.
+ **/
+
+using Genometric.GeUtilities.IGenomics;
 using Genometric.MSPC.Model;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Genometric.MSPC.Core.Model
 {
@@ -11,60 +20,60 @@ namespace Genometric.MSPC.Core.Model
     {
         public ProcessedPeak()
         {
-            statisticalClassification = Attributes.TruePositive;
-            classification = new HashSet<Attributes>();
+            StatisticalClassification = Attributes.TruePositive;
+            Classification = new HashSet<Attributes>();
         }
 
         /// <summary>
         /// Sets and gets the Confirmed I. Is a reference to the original er in cached data.
         /// </summary>
-        public I peak { set; get; }
+        public I Peak { set; get; }
 
         /// <summary>
         /// Sets and gets X-squared of test
         /// </summary>
-        public double xSquared { set; get; }
+        public double XSquared { set; get; }
 
         /// <summary>
         /// Right tailed probability of x-squared.
         /// </summary>
-        public double rtp { set; get; }
+        public double RTP { set; get; }
 
         /// <summary>
         /// Sets and gets the set of peaks intersecting with confirmed er
         /// </summary>
-        public List<SupportingPeak<I>> supportingPeaks { set; get; }
+        public List<SupportingPeak<I>> SupportingPeaks { set; get; }
 
         /// <summary>
         /// Sets and gets the reason of discarding the er. It points to an index of
         /// predefined messages.
         /// </summary>
-        public byte reason { set; get; }
+        public byte Reason { set; get; }
 
         /// <summary>
         /// Sets and gets classification type. 
         /// </summary>
-        public HashSet<Attributes> classification { set; get; }
+        public HashSet<Attributes> Classification { set; get; }
 
         /// <summary>
         /// Sets and gets adjusted p-value using the multiple testing correction method of choice.
         /// </summary>
-        public double adjPValue { set; get; }
+        public double AdjPValue { set; get; }
 
         /// <summary>
         /// Set and gets whether the peaks is identified as false-positive or true-positive 
         /// based on multiple testing correction threshold. 
         /// </summary>
-        public Attributes statisticalClassification { set; get; }
+        public Attributes StatisticalClassification { set; get; }
 
         /// <summary>
         /// Contains different classification types.
         /// </summary>
-        int IComparable<ProcessedPeak<I>>.CompareTo(ProcessedPeak<I> that)
+        int IComparable<ProcessedPeak<I>>.CompareTo(ProcessedPeak<I> other)
         {
-            if (that == null) return 1;
+            if (other == null) return 1;
 
-            return this.peak.CompareTo(that.peak);
+            return Peak.CompareTo(other.Peak);
         }
     }
 }

--- a/Core/Model/ProcessedPeak.cs
+++ b/Core/Model/ProcessedPeak.cs
@@ -21,8 +21,8 @@ namespace Genometric.MSPC.Core.Model
     public class ProcessedPeak<I> : Peak<I>, IComparable<ProcessedPeak<I>>
             where I : IChIPSeqPeak, new()
     {
-        internal ProcessedPeak(I peak, double xSquared, List<SupportingPeak<I>> supportingPeaks, Codes reason = Codes.M000) :
-            this(peak, xSquared, supportingPeaks.AsReadOnly(), reason)
+        internal ProcessedPeak(I source, double xSquared, List<SupportingPeak<I>> supportingPeaks, Codes reason = Codes.M000) :
+            this(source, xSquared, supportingPeaks.AsReadOnly(), reason)
         { }
 
         internal ProcessedPeak(I source, double xSquared, ReadOnlyCollection<SupportingPeak<I>> supportingPeaks, Codes reason = Codes.M000):

--- a/Core/Model/ProcessedPeak.cs
+++ b/Core/Model/ProcessedPeak.cs
@@ -13,17 +13,23 @@ using Genometric.MSPC.Model;
 using Genometric.MSPC.XSquaredData;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Genometric.MSPC.Core.Model
 {
     public class ProcessedPeak<I> : IComparable<ProcessedPeak<I>>
             where I : IChIPSeqPeak, new()
     {
-        public ProcessedPeak(I peak, double xSquared)
+        public ProcessedPeak(I peak, double xSquared, List<SupportingPeak<I>> supportingPeaks) :
+            this(peak, xSquared, supportingPeaks.AsReadOnly())
+        { }
+            
+        public ProcessedPeak(I peak, double xSquared, ReadOnlyCollection<SupportingPeak<I>> supportingPeaks)
         {
             Peak = peak;
             XSquared = xSquared;
-            //RTP = ChiSquaredCache.ChiSqrdDistRTP(xSquared, 2 + (supportingPeaks.Count * 2);
+            RTP = ChiSquaredCache.ChiSqrdDistRTP(xSquared, 2 + (supportingPeaks.Count * 2));
+            SupportingPeaks = supportingPeaks;
             StatisticalClassification = Attributes.TruePositive;
             Classification = new HashSet<Attributes>();
         }
@@ -46,7 +52,7 @@ namespace Genometric.MSPC.Core.Model
         /// <summary>
         /// Sets and gets the set of peaks intersecting with confirmed er
         /// </summary>
-        public List<SupportingPeak<I>> SupportingPeaks { internal set; get; }
+        public ReadOnlyCollection<SupportingPeak<I>> SupportingPeaks { private set; get; }
 
         /// <summary>
         /// Sets and gets the reason of discarding the er. It points to an index of

--- a/Core/Model/ProcessedPeak.cs
+++ b/Core/Model/ProcessedPeak.cs
@@ -14,22 +14,24 @@ using Genometric.MSPC.XSquaredData;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using static Genometric.MSPC.Core.Model.Messages;
 
 namespace Genometric.MSPC.Core.Model
 {
     public class ProcessedPeak<I> : IComparable<ProcessedPeak<I>>
             where I : IChIPSeqPeak, new()
     {
-        public ProcessedPeak(I peak, double xSquared, List<SupportingPeak<I>> supportingPeaks) :
-            this(peak, xSquared, supportingPeaks.AsReadOnly())
+        internal ProcessedPeak(I peak, double xSquared, List<SupportingPeak<I>> supportingPeaks, Codes reason = Codes.M000) :
+            this(peak, xSquared, supportingPeaks.AsReadOnly(), reason)
         { }
             
-        public ProcessedPeak(I peak, double xSquared, ReadOnlyCollection<SupportingPeak<I>> supportingPeaks)
+        internal ProcessedPeak(I peak, double xSquared, ReadOnlyCollection<SupportingPeak<I>> supportingPeaks, Codes reason = Codes.M000)
         {
             Peak = peak;
             XSquared = xSquared;
             RTP = ChiSquaredCache.ChiSqrdDistRTP(xSquared, 2 + (supportingPeaks.Count * 2));
             SupportingPeaks = supportingPeaks;
+            _reason = reason;
             StatisticalClassification = Attributes.TruePositive;
             Classification = new HashSet<Attributes>();
         }
@@ -55,10 +57,11 @@ namespace Genometric.MSPC.Core.Model
         public ReadOnlyCollection<SupportingPeak<I>> SupportingPeaks { private set; get; }
 
         /// <summary>
-        /// Sets and gets the reason of discarding the er. It points to an index of
-        /// predefined messages.
+        /// Gets the reason of discarding this ER. It returns an empty string if 
+        /// this ER is confirmed. 
         /// </summary>
-        public byte Reason { internal set; get; }
+        public string Reason { get { return Decode(_reason); } }
+        private readonly Codes _reason;
 
         /// <summary>
         /// Sets and gets classification type. 

--- a/Core/Model/ProcessedPeak.cs
+++ b/Core/Model/ProcessedPeak.cs
@@ -10,6 +10,7 @@
 
 using Genometric.GeUtilities.IGenomics;
 using Genometric.MSPC.Model;
+using Genometric.MSPC.XSquaredData;
 using System;
 using System.Collections.Generic;
 
@@ -22,6 +23,7 @@ namespace Genometric.MSPC.Core.Model
         {
             Peak = peak;
             XSquared = xSquared;
+            //RTP = ChiSquaredCache.ChiSqrdDistRTP(xSquared, 2 + (supportingPeaks.Count * 2);
             StatisticalClassification = Attributes.TruePositive;
             Classification = new HashSet<Attributes>();
         }
@@ -39,7 +41,7 @@ namespace Genometric.MSPC.Core.Model
         /// <summary>
         /// Right tailed probability of x-squared.
         /// </summary>
-        public double RTP { internal set; get; }
+        public double RTP { private set; get; }
 
         /// <summary>
         /// Sets and gets the set of peaks intersecting with confirmed er

--- a/Core/Model/ProcessedPeak.cs
+++ b/Core/Model/ProcessedPeak.cs
@@ -24,7 +24,7 @@ namespace Genometric.MSPC.Core.Model
         internal ProcessedPeak(I peak, double xSquared, List<SupportingPeak<I>> supportingPeaks, Codes reason = Codes.M000) :
             this(peak, xSquared, supportingPeaks.AsReadOnly(), reason)
         { }
-            
+
         internal ProcessedPeak(I peak, double xSquared, ReadOnlyCollection<SupportingPeak<I>> supportingPeaks, Codes reason = Codes.M000)
         {
             Peak = peak;
@@ -94,6 +94,72 @@ namespace Genometric.MSPC.Core.Model
 
             if (!Classification.Remove(attribute))
                 Classification.Add(attribute);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ProcessedPeak<I> peak &&
+                   EqualityComparer<I>.Default.Equals(Peak, peak.Peak) &&
+                   XSquared == peak.XSquared &&
+                   RTP == peak.RTP &&
+                   EqualityComparer<ReadOnlyCollection<SupportingPeak<I>>>.Default.Equals(SupportingPeaks, peak.SupportingPeaks) &&
+                   Reason == peak.Reason &&
+                   EqualityComparer<HashSet<Attributes>>.Default.Equals(Classification, peak.Classification) &&
+                   AdjPValue == peak.AdjPValue;
+        }
+
+        public override int GetHashCode()
+        {
+            string key = Peak.GetHashCode() + "_" + XSquared + "_" + RTP + "_" + SupportingPeaks.Count;
+            int l = key.Length;
+
+            int hashKey = 0;
+            for (int i = 0; i < l; i++)
+            {
+                hashKey += key[i];
+                hashKey += (hashKey << 10);
+                hashKey ^= (hashKey >> 6);
+            }
+
+            hashKey += (hashKey << 3);
+            hashKey ^= (hashKey >> 11);
+            hashKey += (hashKey << 15);
+
+            return hashKey;
+        }
+
+        public static bool operator >(ProcessedPeak<I> operand1, ProcessedPeak<I> operand2)
+        {
+            return operand1.Peak.CompareTo(operand2.Peak) == 1;
+        }
+
+        public static bool operator <(ProcessedPeak<I> operand1, ProcessedPeak<I> operand2)
+        {
+            return operand1.Peak.CompareTo(operand2.Peak) == -1;
+        }
+
+        public static bool operator >=(ProcessedPeak<I> operand1, ProcessedPeak<I> operand2)
+        {
+            return operand1.Peak.CompareTo(operand2.Peak) >= 0;
+        }
+
+        public static bool operator <=(ProcessedPeak<I> operand1, ProcessedPeak<I> operand2)
+        {
+            return operand1.Peak.CompareTo(operand2.Peak) <= 0;
+        }
+
+        public static bool operator ==(ProcessedPeak<I> operand1, ProcessedPeak<I> operand2)
+        {
+            if (operand1 is null)
+                return operand2 is null;
+            return operand1.Equals(operand2);
+        }
+
+        public static bool operator !=(ProcessedPeak<I> operand1, ProcessedPeak<I> operand2)
+        {
+            if (operand1 is null)
+                return operand2 is null;
+            return !operand1.Equals(operand2);
         }
     }
 }

--- a/Core/Model/ProcessedPeak.cs
+++ b/Core/Model/ProcessedPeak.cs
@@ -18,9 +18,10 @@ namespace Genometric.MSPC.Core.Model
     public class ProcessedPeak<I> : IComparable<ProcessedPeak<I>>
             where I : IChIPSeqPeak, new()
     {
-        public ProcessedPeak(I peak)
+        public ProcessedPeak(I peak, double xSquared)
         {
             Peak = peak;
+            XSquared = xSquared;
             StatisticalClassification = Attributes.TruePositive;
             Classification = new HashSet<Attributes>();
         }
@@ -33,7 +34,7 @@ namespace Genometric.MSPC.Core.Model
         /// <summary>
         /// Sets and gets X-squared of test
         /// </summary>
-        public double XSquared { internal set; get; }
+        public double XSquared { private set; get; }
 
         /// <summary>
         /// Right tailed probability of x-squared.

--- a/Core/Model/Processor.cs
+++ b/Core/Model/Processor.cs
@@ -142,11 +142,11 @@ namespace Genometric.MSPC.Model
                                 if (_xsqrd >= _cachedChiSqrd[supportingPeaks.Count])
                                     ConfirmPeak(sample.Key, chr.Key, peak, supportingPeaks);
                                 else
-                                    DiscardPeak(sample.Key, chr.Key, peak, supportingPeaks, 0);
+                                    DiscardPeak(sample.Key, chr.Key, peak, supportingPeaks, Messages.Codes.M001);
                             }
                             else
                             {
-                                DiscardPeak(sample.Key, chr.Key, peak, supportingPeaks, 1);
+                                DiscardPeak(sample.Key, chr.Key, peak, supportingPeaks, Messages.Codes.M002);
                             }
                         }
 
@@ -256,12 +256,9 @@ namespace Genometric.MSPC.Model
             }
         }
 
-        private void DiscardPeak(uint id, string chr, I p, List<SupportingPeak<I>> supportingPeaks, byte discardReason)
+        private void DiscardPeak(uint id, string chr, I p, List<SupportingPeak<I>> supportingPeaks, Messages.Codes discardReason)
         {
-            var anRe = new ProcessedPeak<I>(p, _xsqrd, supportingPeaks)
-            {
-                Reason = discardReason
-            };
+            var anRe = new ProcessedPeak<I>(p, _xsqrd, supportingPeaks, discardReason);
 
             if (p.Value <= _config.TauS)
             {
@@ -286,7 +283,7 @@ namespace Genometric.MSPC.Model
                 DiscardSupportingPeaks(id, chr, p, supportingPeaks, discardReason);
         }
 
-        private void DiscardSupportingPeaks(uint id, string chr, I p, List<SupportingPeak<I>> supportingPeaks, byte discardReason)
+        private void DiscardSupportingPeaks(uint id, string chr, I p, List<SupportingPeak<I>> supportingPeaks, Messages.Codes discardReason)
         {
             foreach (var supPeak in supportingPeaks)
             {
@@ -300,10 +297,7 @@ namespace Genometric.MSPC.Model
                         if (supPeak.CompareTo(sP) != 0)
                             tSupPeak.Add(sP);
 
-                    var anRe = new ProcessedPeak<I>(supPeak.peak, _xsqrd, tSupPeak)
-                    {
-                        Reason = discardReason
-                    };
+                    var anRe = new ProcessedPeak<I>(supPeak.peak, _xsqrd, tSupPeak, discardReason);
 
                     if (supPeak.peak.Value <= _config.TauS)
                     {

--- a/Core/Model/Processor.cs
+++ b/Core/Model/Processor.cs
@@ -214,9 +214,8 @@ namespace Genometric.MSPC.Model
 
         private void ConfirmPeak(uint id, string chr, I p, List<SupportingPeak<I>> supportingPeaks)
         {
-            var anRe = new ProcessedPeak<I>()
+            var anRe = new ProcessedPeak<I>(p)
             {
-                Peak = p,
                 XSquared = _xsqrd,
                 RTP = ChiSquaredCache.ChiSqrdDistRTP(_xsqrd, 2 + (supportingPeaks.Count * 2)),
                 SupportingPeaks = supportingPeaks
@@ -246,9 +245,8 @@ namespace Genometric.MSPC.Model
                         if (supPeak.CompareTo(sP) != 0)
                             tSupPeak.Add(sP);
 
-                    var anRe = new ProcessedPeak<I>()
+                    var anRe = new ProcessedPeak<I>(supPeak.peak)
                     {
-                        Peak = supPeak.peak,
                         XSquared = _xsqrd,
                         RTP = ChiSquaredCache.ChiSqrdDistRTP(_xsqrd, 2 + (supportingPeaks.Count * 2)),
                         SupportingPeaks = tSupPeak
@@ -270,9 +268,8 @@ namespace Genometric.MSPC.Model
 
         private void DiscardPeak(uint id, string chr, I p, List<SupportingPeak<I>> supportingPeaks, byte discardReason)
         {
-            var anRe = new ProcessedPeak<I>
+            var anRe = new ProcessedPeak<I>(p)
             {
-                Peak = p,
                 XSquared = _xsqrd,
                 Reason = discardReason,
                 SupportingPeaks = supportingPeaks
@@ -315,9 +312,8 @@ namespace Genometric.MSPC.Model
                         if (supPeak.CompareTo(sP) != 0)
                             tSupPeak.Add(sP);
 
-                    var anRe = new ProcessedPeak<I>()
+                    var anRe = new ProcessedPeak<I>(supPeak.peak)
                     {
-                        Peak = supPeak.peak,
                         XSquared = _xsqrd,
                         Reason = discardReason,
                         RTP = ChiSquaredCache.ChiSqrdDistRTP(_xsqrd, 2 + (supportingPeaks.Count * 2)),
@@ -413,9 +409,8 @@ namespace Genometric.MSPC.Model
                 {
                     foreach (var confirmedPeak in chr.Value.Get(Attributes.Confirmed))
                     {
-                        var outputPeak = new ProcessedPeak<I>()
+                        var outputPeak = new ProcessedPeak<I>(confirmedPeak.Peak)
                         {
-                            Peak = confirmedPeak.Peak,
                             RTP = confirmedPeak.RTP,
                             XSquared = confirmedPeak.XSquared,
                             SupportingPeaks = confirmedPeak.SupportingPeaks,

--- a/Core/Model/Processor.cs
+++ b/Core/Model/Processor.cs
@@ -216,7 +216,6 @@ namespace Genometric.MSPC.Model
         {
             var anRe = new ProcessedPeak<I>(p, _xsqrd)
             {
-                RTP = ChiSquaredCache.ChiSqrdDistRTP(_xsqrd, 2 + (supportingPeaks.Count * 2)),
                 SupportingPeaks = supportingPeaks
             };
 
@@ -246,7 +245,6 @@ namespace Genometric.MSPC.Model
 
                     var anRe = new ProcessedPeak<I>(supPeak.peak, _xsqrd)
                     {
-                        RTP = ChiSquaredCache.ChiSqrdDistRTP(_xsqrd, 2 + (supportingPeaks.Count * 2)),
                         SupportingPeaks = tSupPeak
                     };
 
@@ -312,7 +310,6 @@ namespace Genometric.MSPC.Model
                     var anRe = new ProcessedPeak<I>(supPeak.peak, _xsqrd)
                     {
                         Reason = discardReason,
-                        RTP = ChiSquaredCache.ChiSqrdDistRTP(_xsqrd, 2 + (supportingPeaks.Count * 2)),
                         SupportingPeaks = tSupPeak
                     };
 
@@ -407,7 +404,6 @@ namespace Genometric.MSPC.Model
                     {
                         var outputPeak = new ProcessedPeak<I>(confirmedPeak.Peak, confirmedPeak.XSquared)
                         {
-                            RTP = confirmedPeak.RTP,
                             SupportingPeaks = confirmedPeak.SupportingPeaks,
                         };
                         outputPeak.Classification.Add(Attributes.TruePositive);

--- a/Core/Model/Processor.cs
+++ b/Core/Model/Processor.cs
@@ -433,12 +433,12 @@ namespace Genometric.MSPC.Model
                             for (int l = 1; l < k; l++)
                             {
                                 outputSet[l].AdjPValue = (((double)k * outputSet[l].Peak.Value) / (double)m) * _config.Alpha;
-                                outputSet[l].StatisticalClassification = Attributes.TruePositive;
+                                outputSet[l].SetStatisticalClassification(Attributes.TruePositive);
                             }
                             for (int l = k; l < m; l++)
                             {
                                 outputSet[l].AdjPValue = (((double)k * outputSet[l].Peak.Value) / (double)m) * _config.Alpha;
-                                outputSet[l].StatisticalClassification = Attributes.FalsePositive;
+                                outputSet[l].SetStatisticalClassification(Attributes.FalsePositive);
                             }
 
                             chr.Value.SetTruePositiveCount((uint)k);

--- a/Core/Model/Processor.cs
+++ b/Core/Model/Processor.cs
@@ -216,16 +216,16 @@ namespace Genometric.MSPC.Model
         {
             var anRe = new ProcessedPeak<I>()
             {
-                peak = p,
-                xSquared = _xsqrd,
-                rtp = ChiSquaredCache.ChiSqrdDistRTP(_xsqrd, 2 + (supportingPeaks.Count * 2)),
-                supportingPeaks = supportingPeaks
+                Peak = p,
+                XSquared = _xsqrd,
+                RTP = ChiSquaredCache.ChiSqrdDistRTP(_xsqrd, 2 + (supportingPeaks.Count * 2)),
+                SupportingPeaks = supportingPeaks
             };
 
             if (p.Value <= _config.TauS)
-                anRe.classification.Add(Attributes.StringentConfirmed);
+                anRe.Classification.Add(Attributes.StringentConfirmed);
             else
-                anRe.classification.Add(Attributes.WeakConfirmed);
+                anRe.Classification.Add(Attributes.WeakConfirmed);
 
             _analysisResults[id].Chromosomes[chr].Add(anRe, Attributes.Confirmed);
 
@@ -248,19 +248,19 @@ namespace Genometric.MSPC.Model
 
                     var anRe = new ProcessedPeak<I>()
                     {
-                        peak = supPeak.peak,
-                        xSquared = _xsqrd,
-                        rtp = ChiSquaredCache.ChiSqrdDistRTP(_xsqrd, 2 + (supportingPeaks.Count * 2)),
-                        supportingPeaks = tSupPeak
+                        Peak = supPeak.peak,
+                        XSquared = _xsqrd,
+                        RTP = ChiSquaredCache.ChiSqrdDistRTP(_xsqrd, 2 + (supportingPeaks.Count * 2)),
+                        SupportingPeaks = tSupPeak
                     };
 
                     if (supPeak.peak.Value <= _config.TauS)
                     {
-                        anRe.classification.Add(Attributes.StringentConfirmed);
+                        anRe.Classification.Add(Attributes.StringentConfirmed);
                     }
                     else
                     {
-                        anRe.classification.Add(Attributes.WeakConfirmed);
+                        anRe.Classification.Add(Attributes.WeakConfirmed);
                     }
 
                     targetSample.Chromosomes[chr].Add(anRe, Attributes.Confirmed);
@@ -272,27 +272,27 @@ namespace Genometric.MSPC.Model
         {
             var anRe = new ProcessedPeak<I>
             {
-                peak = p,
-                xSquared = _xsqrd,
-                reason = discardReason,
-                supportingPeaks = supportingPeaks
+                Peak = p,
+                XSquared = _xsqrd,
+                Reason = discardReason,
+                SupportingPeaks = supportingPeaks
             };
 
             if (p.Value <= _config.TauS)
             {
                 // The cause of discarding the region is :
                 if (supportingPeaks.Count + 1 >= _config.C)
-                    anRe.classification.Add(Attributes.StringentDiscardedT);
+                    anRe.Classification.Add(Attributes.StringentDiscardedT);
                 else
-                    anRe.classification.Add(Attributes.StringentDiscardedC);
+                    anRe.Classification.Add(Attributes.StringentDiscardedC);
             }
             else
             {
                 // The cause of discarding the region is :
                 if (supportingPeaks.Count + 1 >= _config.C)
-                    anRe.classification.Add(Attributes.WeakDiscardedT);
+                    anRe.Classification.Add(Attributes.WeakDiscardedT);
                 else
-                    anRe.classification.Add(Attributes.WeakDiscardedC);
+                    anRe.Classification.Add(Attributes.WeakDiscardedC);
             }
 
             _analysisResults[id].Chromosomes[chr].Add(anRe, Attributes.Discarded);
@@ -317,28 +317,28 @@ namespace Genometric.MSPC.Model
 
                     var anRe = new ProcessedPeak<I>()
                     {
-                        peak = supPeak.peak,
-                        xSquared = _xsqrd,
-                        reason = discardReason,
-                        rtp = ChiSquaredCache.ChiSqrdDistRTP(_xsqrd, 2 + (supportingPeaks.Count * 2)),
-                        supportingPeaks = tSupPeak
+                        Peak = supPeak.peak,
+                        XSquared = _xsqrd,
+                        Reason = discardReason,
+                        RTP = ChiSquaredCache.ChiSqrdDistRTP(_xsqrd, 2 + (supportingPeaks.Count * 2)),
+                        SupportingPeaks = tSupPeak
                     };
 
                     if (supPeak.peak.Value <= _config.TauS)
                     {
                         // The cause of discarding the region is :
                         if (supportingPeaks.Count + 1 >= _config.C)
-                            anRe.classification.Add(Attributes.StringentDiscardedT);
+                            anRe.Classification.Add(Attributes.StringentDiscardedT);
                         else
-                            anRe.classification.Add(Attributes.StringentDiscardedC);
+                            anRe.Classification.Add(Attributes.StringentDiscardedC);
                     }
                     else
                     {
                         // The cause of discarding the region is :
                         if (supportingPeaks.Count + 1 >= _config.C)
-                            anRe.classification.Add(Attributes.WeakDiscardedT);
+                            anRe.Classification.Add(Attributes.WeakDiscardedT);
                         else
-                            anRe.classification.Add(Attributes.WeakDiscardedC);
+                            anRe.Classification.Add(Attributes.WeakDiscardedC);
                     }
 
                     targetSample.Chromosomes[chr].Add(anRe, Attributes.Discarded);
@@ -415,21 +415,21 @@ namespace Genometric.MSPC.Model
                     {
                         var outputPeak = new ProcessedPeak<I>()
                         {
-                            peak = confirmedPeak.peak,
-                            rtp = confirmedPeak.rtp,
-                            xSquared = confirmedPeak.xSquared,
-                            supportingPeaks = confirmedPeak.supportingPeaks,
+                            Peak = confirmedPeak.Peak,
+                            RTP = confirmedPeak.RTP,
+                            XSquared = confirmedPeak.XSquared,
+                            SupportingPeaks = confirmedPeak.SupportingPeaks,
                         };
-                        outputPeak.classification.Add(Attributes.TruePositive);
+                        outputPeak.Classification.Add(Attributes.TruePositive);
 
-                        if (confirmedPeak.peak.Value <= _config.TauS)
+                        if (confirmedPeak.Peak.Value <= _config.TauS)
                         {
-                            outputPeak.classification.Add(Attributes.StringentConfirmed);
+                            outputPeak.Classification.Add(Attributes.StringentConfirmed);
                             /// result.Value.R_j___so[chr.Key]++;
                         }
-                        else if (confirmedPeak.peak.Value <= _config.TauW)
+                        else if (confirmedPeak.Peak.Value <= _config.TauW)
                         {
-                            outputPeak.classification.Add(Attributes.WeakConfirmed);
+                            outputPeak.Classification.Add(Attributes.WeakConfirmed);
                             /// result.Value.R_j___wo[chr.Key]++;
                         }
 
@@ -458,18 +458,18 @@ namespace Genometric.MSPC.Model
 
                     for (int k = 1; k <= m; k++)
                     {
-                        if (outputSet[k - 1].peak.Value > ((double)k / (double)m) * _config.Alpha)
+                        if (outputSet[k - 1].Peak.Value > ((double)k / (double)m) * _config.Alpha)
                         {
                             k--;
                             for (int l = 1; l < k; l++)
                             {
-                                outputSet[l].adjPValue = (((double)k * outputSet[l].peak.Value) / (double)m) * _config.Alpha;
-                                outputSet[l].statisticalClassification = Attributes.TruePositive;
+                                outputSet[l].AdjPValue = (((double)k * outputSet[l].Peak.Value) / (double)m) * _config.Alpha;
+                                outputSet[l].StatisticalClassification = Attributes.TruePositive;
                             }
                             for (int l = k; l < m; l++)
                             {
-                                outputSet[l].adjPValue = (((double)k * outputSet[l].peak.Value) / (double)m) * _config.Alpha;
-                                outputSet[l].statisticalClassification = Attributes.FalsePositive;
+                                outputSet[l].AdjPValue = (((double)k * outputSet[l].Peak.Value) / (double)m) * _config.Alpha;
+                                outputSet[l].StatisticalClassification = Attributes.FalsePositive;
                             }
 
                             chr.Value.SetTruePositiveCount((uint)k);
@@ -497,7 +497,7 @@ namespace Genometric.MSPC.Model
 
                     foreach (var outputER in chr.Value.Get(Attributes.Output))
                     {
-                        var peak = outputER.peak;
+                        var peak = outputER.Peak;
                         var interval = new I();
                         interval.Left = peak.Left;
                         interval.Right = peak.Right;

--- a/Core/Model/Processor.cs
+++ b/Core/Model/Processor.cs
@@ -214,9 +214,8 @@ namespace Genometric.MSPC.Model
 
         private void ConfirmPeak(uint id, string chr, I p, List<SupportingPeak<I>> supportingPeaks)
         {
-            var anRe = new ProcessedPeak<I>(p)
+            var anRe = new ProcessedPeak<I>(p, _xsqrd)
             {
-                XSquared = _xsqrd,
                 RTP = ChiSquaredCache.ChiSqrdDistRTP(_xsqrd, 2 + (supportingPeaks.Count * 2)),
                 SupportingPeaks = supportingPeaks
             };
@@ -245,9 +244,8 @@ namespace Genometric.MSPC.Model
                         if (supPeak.CompareTo(sP) != 0)
                             tSupPeak.Add(sP);
 
-                    var anRe = new ProcessedPeak<I>(supPeak.peak)
+                    var anRe = new ProcessedPeak<I>(supPeak.peak, _xsqrd)
                     {
-                        XSquared = _xsqrd,
                         RTP = ChiSquaredCache.ChiSqrdDistRTP(_xsqrd, 2 + (supportingPeaks.Count * 2)),
                         SupportingPeaks = tSupPeak
                     };
@@ -268,9 +266,8 @@ namespace Genometric.MSPC.Model
 
         private void DiscardPeak(uint id, string chr, I p, List<SupportingPeak<I>> supportingPeaks, byte discardReason)
         {
-            var anRe = new ProcessedPeak<I>(p)
+            var anRe = new ProcessedPeak<I>(p, _xsqrd)
             {
-                XSquared = _xsqrd,
                 Reason = discardReason,
                 SupportingPeaks = supportingPeaks
             };
@@ -312,9 +309,8 @@ namespace Genometric.MSPC.Model
                         if (supPeak.CompareTo(sP) != 0)
                             tSupPeak.Add(sP);
 
-                    var anRe = new ProcessedPeak<I>(supPeak.peak)
+                    var anRe = new ProcessedPeak<I>(supPeak.peak, _xsqrd)
                     {
-                        XSquared = _xsqrd,
                         Reason = discardReason,
                         RTP = ChiSquaredCache.ChiSqrdDistRTP(_xsqrd, 2 + (supportingPeaks.Count * 2)),
                         SupportingPeaks = tSupPeak
@@ -409,10 +405,9 @@ namespace Genometric.MSPC.Model
                 {
                     foreach (var confirmedPeak in chr.Value.Get(Attributes.Confirmed))
                     {
-                        var outputPeak = new ProcessedPeak<I>(confirmedPeak.Peak)
+                        var outputPeak = new ProcessedPeak<I>(confirmedPeak.Peak, confirmedPeak.XSquared)
                         {
                             RTP = confirmedPeak.RTP,
-                            XSquared = confirmedPeak.XSquared,
                             SupportingPeaks = confirmedPeak.SupportingPeaks,
                         };
                         outputPeak.Classification.Add(Attributes.TruePositive);

--- a/Core/Model/Processor.cs
+++ b/Core/Model/Processor.cs
@@ -214,10 +214,7 @@ namespace Genometric.MSPC.Model
 
         private void ConfirmPeak(uint id, string chr, I p, List<SupportingPeak<I>> supportingPeaks)
         {
-            var anRe = new ProcessedPeak<I>(p, _xsqrd)
-            {
-                SupportingPeaks = supportingPeaks
-            };
+            var anRe = new ProcessedPeak<I>(p, _xsqrd, supportingPeaks);
 
             if (p.Value <= _config.TauS)
                 anRe.Classification.Add(Attributes.StringentConfirmed);
@@ -243,10 +240,7 @@ namespace Genometric.MSPC.Model
                         if (supPeak.CompareTo(sP) != 0)
                             tSupPeak.Add(sP);
 
-                    var anRe = new ProcessedPeak<I>(supPeak.peak, _xsqrd)
-                    {
-                        SupportingPeaks = tSupPeak
-                    };
+                    var anRe = new ProcessedPeak<I>(supPeak.peak, _xsqrd, tSupPeak);
 
                     if (supPeak.peak.Value <= _config.TauS)
                     {
@@ -264,10 +258,9 @@ namespace Genometric.MSPC.Model
 
         private void DiscardPeak(uint id, string chr, I p, List<SupportingPeak<I>> supportingPeaks, byte discardReason)
         {
-            var anRe = new ProcessedPeak<I>(p, _xsqrd)
+            var anRe = new ProcessedPeak<I>(p, _xsqrd, supportingPeaks)
             {
-                Reason = discardReason,
-                SupportingPeaks = supportingPeaks
+                Reason = discardReason
             };
 
             if (p.Value <= _config.TauS)
@@ -307,10 +300,9 @@ namespace Genometric.MSPC.Model
                         if (supPeak.CompareTo(sP) != 0)
                             tSupPeak.Add(sP);
 
-                    var anRe = new ProcessedPeak<I>(supPeak.peak, _xsqrd)
+                    var anRe = new ProcessedPeak<I>(supPeak.peak, _xsqrd, tSupPeak)
                     {
-                        Reason = discardReason,
-                        SupportingPeaks = tSupPeak
+                        Reason = discardReason
                     };
 
                     if (supPeak.peak.Value <= _config.TauS)
@@ -402,10 +394,7 @@ namespace Genometric.MSPC.Model
                 {
                     foreach (var confirmedPeak in chr.Value.Get(Attributes.Confirmed))
                     {
-                        var outputPeak = new ProcessedPeak<I>(confirmedPeak.Peak, confirmedPeak.XSquared)
-                        {
-                            SupportingPeaks = confirmedPeak.SupportingPeaks,
-                        };
+                        var outputPeak = new ProcessedPeak<I>(confirmedPeak.Peak, confirmedPeak.XSquared, confirmedPeak.SupportingPeaks);
                         outputPeak.Classification.Add(Attributes.TruePositive);
 
                         if (confirmedPeak.Peak.Value <= _config.TauS)

--- a/Core/Model/Sets.cs
+++ b/Core/Model/Sets.cs
@@ -61,17 +61,17 @@ namespace Genometric.MSPC.Model
             {
                 case Attributes.Confirmed:
                 case Attributes.Discarded:
-                    if (!_sets[type].ContainsKey(peak.Peak.HashKey))
+                    if (!_sets[type].ContainsKey(peak.Source.HashKey))
                     {
-                        _sets[type].Add(peak.Peak.HashKey, peak);
+                        _sets[type].Add(peak.Source.HashKey, peak);
                         foreach (var att in peak.Classification)
                             _stats[att]++;
                     }
                     break;
 
                 case Attributes.Output:
-                    if (!_sets[type].ContainsKey(peak.Peak.HashKey))
-                        _sets[type].Add(peak.Peak.HashKey, peak);
+                    if (!_sets[type].ContainsKey(peak.Source.HashKey))
+                        _sets[type].Add(peak.Source.HashKey, peak);
                     break;
 
                 default:

--- a/Core/Model/Sets.cs
+++ b/Core/Model/Sets.cs
@@ -61,17 +61,17 @@ namespace Genometric.MSPC.Model
             {
                 case Attributes.Confirmed:
                 case Attributes.Discarded:
-                    if (!_sets[type].ContainsKey(peak.peak.HashKey))
+                    if (!_sets[type].ContainsKey(peak.Peak.HashKey))
                     {
-                        _sets[type].Add(peak.peak.HashKey, peak);
-                        foreach (var att in peak.classification)
+                        _sets[type].Add(peak.Peak.HashKey, peak);
+                        foreach (var att in peak.Classification)
                             _stats[att]++;
                     }
                     break;
 
                 case Attributes.Output:
-                    if (!_sets[type].ContainsKey(peak.peak.HashKey))
-                        _sets[type].Add(peak.peak.HashKey, peak);
+                    if (!_sets[type].ContainsKey(peak.Peak.HashKey))
+                        _sets[type].Add(peak.Peak.HashKey, peak);
                     break;
 
                 default:

--- a/Core/Model/SupportingPeak.cs
+++ b/Core/Model/SupportingPeak.cs
@@ -1,56 +1,33 @@
-﻿using Genometric.GeUtilities.IGenomics;
+﻿/** Copyright © 2014-2015 Vahid Jalili
+ * 
+ * This file is part of MSPC project.
+ * MSPC is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ * MSPC is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with Foobar. If not, see http://www.gnu.org/licenses/.
+ **/
+
+using Genometric.GeUtilities.IGenomics;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Genometric.MSPC.Core.Model
 {
-    public class SupportingPeak<I> : IComparable<SupportingPeak<I>>
+    public class SupportingPeak<I> : Peak<I>, IComparable<SupportingPeak<I>>
             where I : IChIPSeqPeak, new()
     {
-        /// <summary>
-        /// Sets and gets the source of the er in cached data. 
-        /// </summary>
-        public UInt32 sampleID { set; get; }
-
-        /// <summary>
-        /// Sets and gets the supporting er.
-        /// </summary>
-        public I peak { set; get; }
-
-        int IComparable<SupportingPeak<I>>.CompareTo(SupportingPeak<I> that)
+        public SupportingPeak(I source, UInt32 sampleID):
+            base(source)
         {
-            return CompareWithThis(that);
+            SampleID = sampleID;
         }
 
-        public int CompareTo(object obj)
+        public UInt32 SampleID { private set; get; }
+
+        int IComparable<SupportingPeak<I>>.CompareTo(SupportingPeak<I> other)
         {
-            return CompareWithThis((SupportingPeak<I>)obj);
-        }
-
-        private int CompareWithThis(SupportingPeak<I> that)
-        {
-            if (that == null) return 1;
-
-            if (this.sampleID != that.sampleID)
-                return this.sampleID.CompareTo(that.sampleID);
-
-            if (this.peak.Left != that.peak.Left)
-                return this.peak.Left.CompareTo(that.peak.Left);
-
-            if (this.peak.Right != that.peak.Right)
-                return this.peak.Right.CompareTo(that.peak.Right);
-
-            /*if (this.er.metadata.strand != that.er.metadata.strand)
-                return this.er.metadata.strand.CompareTo(that.er.metadata.strand);*/
-
-            if (this.peak.Value != that.peak.Value)
-                return this.peak.Value.CompareTo(that.peak.Value);
-
-            /*if (this.er.metadata.name != that.er.metadata.name)
-                return this.er.metadata.name.CompareTo(that.er.metadata.name);*/
-
-            return 0;
+            if (other == null) return 1;
+            return CompareTo(other);
         }
     }
 }


### PR DESCRIPTION
- Refactor properties of the `ProcessedPeak` class to adhere with the pascal naming convention;
- Set the accessibility of all properties of the `ProcessedPeak` class to private, and receive all the values via constructors; 
- Create `Peak` class and set it as the base for `ProcessedPeak` and `SupportingPeak` classes. 
