### PR TITLE
Remove Stats property of the Sets class.

### DIFF
--- a/Core.Tests/Example/Eg1.cs
+++ b/Core.Tests/Example/Eg1.cs
@@ -124,11 +124,10 @@ namespace Core.Tests.Example
 
             // Assert
             Assert.True(qres.Count == expectedCount);
-            Assert.True(res[sampleIndex].Chromosomes["chr1"].Stats[attribute] == expectedCount);
         }
 
         [Theory]
-        //[InlineData(ReplicateType.Technical, 3, 0, Attributes.Confirmed, 1)]
+        [InlineData(ReplicateType.Technical, 3, 0, Attributes.Confirmed, 1)]
         [InlineData(ReplicateType.Technical, 3, 0, Attributes.Discarded, 1)]
         [InlineData(ReplicateType.Technical, 3, 1, Attributes.Confirmed, 1)]
         [InlineData(ReplicateType.Technical, 3, 1, Attributes.Discarded, 2)]
@@ -151,7 +150,6 @@ namespace Core.Tests.Example
 
             // Assert
             Assert.True(qres.Count == expectedCount);
-            Assert.True(res[sampleIndex].Chromosomes["chr1"].Stats[attribute] == expectedCount);
         }
     }
 }

--- a/Core.Tests/SetsAndAttributes/BackgroundPeaks.cs
+++ b/Core.Tests/SetsAndAttributes/BackgroundPeaks.cs
@@ -49,17 +49,6 @@ namespace Core.Tests.Base
         }
 
         [Fact]
-        public void CountBackgroundAttribute()
-        {
-            // Arrange & Act
-            var res = GenerateAndProcessBackgroundPeaks();
-
-            // Assert
-            foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Stats[Attributes.Background] == 1);
-        }
-
-        [Fact]
         public void BackgroundPeaksShouldNotHaveAnyOtherAttributes()
         {
             // Arrange & Act
@@ -74,23 +63,6 @@ namespace Core.Tests.Base
                     s.Value.Chromosomes[_chr].Get(Attributes.Discarded).Count == 0 &&
                     s.Value.Chromosomes[_chr].Get(Attributes.TruePositive).Count == 0 &&
                     s.Value.Chromosomes[_chr].Get(Attributes.FalsePositive).Count == 0);
-        }
-
-        [Fact]
-        public void CountBackgroundPeaksShouldNotHaveAnyOtherAttributes()
-        {
-            // Arrange & Act
-            var res = GenerateAndProcessBackgroundPeaks();
-
-            // Assert
-            foreach (var s in res)
-                Assert.True(
-                    s.Value.Chromosomes[_chr].Stats[Attributes.Weak] == 0 &&
-                    s.Value.Chromosomes[_chr].Stats[Attributes.Stringent] == 0 &&
-                    s.Value.Chromosomes[_chr].Stats[Attributes.Confirmed] == 0 &&
-                    s.Value.Chromosomes[_chr].Stats[Attributes.Discarded] == 0 &&
-                    s.Value.Chromosomes[_chr].Stats[Attributes.TruePositive] == 0 &&
-                    s.Value.Chromosomes[_chr].Stats[Attributes.FalsePositive] == 0);
         }
 
         [Fact]
@@ -117,29 +89,6 @@ namespace Core.Tests.Base
         }
 
         [Fact]
-        public void CountNonOverlappingBackgroundPeaks()
-        {
-            // Arrange
-            var sA = new BED<ChIPSeqPeak>();
-            sA.Add(new ChIPSeqPeak() { Left = 10, Right = 20, Value = 1e-2 }, _chr, _strand);
-
-            var sB = new BED<ChIPSeqPeak>();
-            sB.Add(new ChIPSeqPeak() { Left = 50, Right = 60, Value = 1e-4 }, _chr, _strand);
-
-            var mspc = new MSPC<ChIPSeqPeak>();
-            mspc.AddSample(0, sA);
-            mspc.AddSample(1, sB);
-
-            var config = new Config(ReplicateType.Biological, 1e-4, 1e-8, 1e-4, 2, 1F, MultipleIntersections.UseLowestPValue);
-
-            // Act
-            var res = mspc.Run(config);
-
-            foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Stats[Attributes.Background] == 1);
-        }
-
-        [Fact]
         public void BackgroundOverlappingNonBackground()
         {
             // Arrange
@@ -161,30 +110,6 @@ namespace Core.Tests.Base
             Assert.True(
                 res[0].Chromosomes[_chr].GetInitialClassifications(Attributes.Background).Count == 1 &&
                 res[1].Chromosomes[_chr].GetInitialClassifications(Attributes.Background).Count == 0);
-        }
-
-        [Fact]
-        public void CountBackgroundOverlappingNonBackground()
-        {
-            // Arrange
-            var sA = new BED<ChIPSeqPeak>();
-            sA.Add(new ChIPSeqPeak() { Left = 10, Right = 20, Value = 1e-2 }, _chr, _strand);
-
-            var sB = new BED<ChIPSeqPeak>();
-            sB.Add(new ChIPSeqPeak() { Left = 50, Right = 60, Value = 1e-8 }, _chr, _strand);
-
-            var mspc = new MSPC<ChIPSeqPeak>();
-            mspc.AddSample(0, sA);
-            mspc.AddSample(1, sB);
-
-            var config = new Config(ReplicateType.Biological, 1e-4, 1e-8, 1e-4, 2, 1F, MultipleIntersections.UseLowestPValue);
-
-            // Act
-            var res = mspc.Run(config);
-
-            Assert.True(
-                res[0].Chromosomes[_chr].Stats[Attributes.Background] == 1 &&
-                res[1].Chromosomes[_chr].Stats[Attributes.Background] == 0);
         }
 
         [Fact]

--- a/Core.Tests/SetsAndAttributes/Confirmed.cs
+++ b/Core.Tests/SetsAndAttributes/Confirmed.cs
@@ -49,17 +49,6 @@ namespace Core.Tests.Base
         }
 
         [Fact]
-        public void CountConfirmedAttributes()
-        {
-            // Arrange & Act
-            var res = CreateStringentPeaksAndConfirmThem();
-
-            // Assert
-            foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Stats[Attributes.Confirmed] == 1);
-        }
-
-        [Fact]
         public void ConfirmTwoOverlappingWeakPeaks()
         {
             // Arrange
@@ -81,30 +70,6 @@ namespace Core.Tests.Base
             // Assert
             foreach (var s in res)
                 Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Confirmed).Count == 1);
-        }
-
-        [Fact]
-        public void CountConfirmedTwoOverlappingWeakPeaks()
-        {
-            // Arrange
-            var sA = new BED<ChIPSeqPeak>();
-            sA.Add(new ChIPSeqPeak() { Left = 10, Right = 20, Value = 7e-5 }, _chr, _strand);
-
-            var sB = new BED<ChIPSeqPeak>();
-            sB.Add(new ChIPSeqPeak() { Left = 5, Right = 12, Value = 7e-5 }, _chr, _strand);
-
-            var mspc = new MSPC<ChIPSeqPeak>();
-            mspc.AddSample(0, sA);
-            mspc.AddSample(1, sB);
-
-            var config = new Config(ReplicateType.Biological, 1e-4, 1e-8, 1e-7, 2, 1F, MultipleIntersections.UseLowestPValue);
-
-            // Act
-            var res = mspc.Run(config);
-
-            // Assert
-            foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Stats[Attributes.Confirmed] == 1);
         }
 
         [Fact]
@@ -132,30 +97,6 @@ namespace Core.Tests.Base
         }
 
         [Fact]
-        public void CountConfirmTwoNonOverlappingWeakPeaks()
-        {
-            // Arrange
-            var sA = new BED<ChIPSeqPeak>();
-            sA.Add(new ChIPSeqPeak() { Left = 10, Right = 20, Value = 1e-6 }, _chr, _strand);
-
-            var sB = new BED<ChIPSeqPeak>();
-            sB.Add(new ChIPSeqPeak() { Left = 50, Right = 60, Value = 1e-6 }, _chr, _strand);
-
-            var mspc = new MSPC<ChIPSeqPeak>();
-            mspc.AddSample(0, sA);
-            mspc.AddSample(1, sB);
-
-            var config = new Config(ReplicateType.Biological, 1e-4, 1e-8, 1e-6, 1, 1F, MultipleIntersections.UseLowestPValue);
-
-            // Act
-            var res = mspc.Run(config);
-
-            // Assert
-            foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Stats[Attributes.Confirmed] == 1);
-        }
-
-        [Fact]
         public void NoDiscardedAttributeForConfirmedPeaks()
         {
             // Arrange & Act
@@ -164,17 +105,6 @@ namespace Core.Tests.Base
             // Assert
             foreach (var s in res)
                 Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Discarded).Count == 0);
-        }
-
-        [Fact]
-        public void CountNoDiscardedAttributeForConfirmedPeaks()
-        {
-            // Arrange & Act
-            var res = CreateStringentPeaksAndConfirmThem();
-
-            // Assert
-            foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Stats[Attributes.Discarded] == 0);
         }
 
         [Fact]

--- a/Core.Tests/SetsAndAttributes/Discarded.cs
+++ b/Core.Tests/SetsAndAttributes/Discarded.cs
@@ -49,17 +49,6 @@ namespace Core.Tests.Base
         }
 
         [Fact]
-        public void CountDiscardedAttribute()
-        {
-            // Arrange & Act
-            var res = CreateStringentPeaksAndDiscardThem();
-
-            // Assert
-            foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Stats[Attributes.Discarded] == 1);
-        }
-
-        [Fact]
         public void DiscardTwoOverlappingWeakPeaks()
         {
             // Arrange
@@ -81,30 +70,6 @@ namespace Core.Tests.Base
             // Assert
             foreach (var s in res)
                 Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Discarded).Count == 1);
-        }
-
-        [Fact]
-        public void CountDiscardTwoOverlappingWeakPeaks()
-        {
-            // Arrange
-            var sA = new BED<ChIPSeqPeak>();
-            sA.Add(new ChIPSeqPeak() { Left = 10, Right = 20, Value = 7e-5 }, _chr, _strand);
-
-            var sB = new BED<ChIPSeqPeak>();
-            sB.Add(new ChIPSeqPeak() { Left = 5, Right = 12, Value = 7e-5 }, _chr, _strand);
-
-            var mspc = new MSPC<ChIPSeqPeak>();
-            mspc.AddSample(0, sA);
-            mspc.AddSample(1, sB);
-
-            var config = new Config(ReplicateType.Biological, 1e-4, 1e-8, 1e-8, 2, 1F, MultipleIntersections.UseLowestPValue);
-
-            // Act
-            var res = mspc.Run(config);
-
-            // Assert
-            foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Stats[Attributes.Discarded] == 1);
         }
 
         [Fact]
@@ -132,30 +97,6 @@ namespace Core.Tests.Base
         }
 
         [Fact]
-        public void CountDiscardTwoNonOverlappingWeakPeaks()
-        {
-            // Arrange
-            var sA = new BED<ChIPSeqPeak>();
-            sA.Add(new ChIPSeqPeak() { Left = 10, Right = 20, Value = 1e-6 }, _chr, _strand);
-
-            var sB = new BED<ChIPSeqPeak>();
-            sB.Add(new ChIPSeqPeak() { Left = 50, Right = 60, Value = 1e-6 }, _chr, _strand);
-
-            var mspc = new MSPC<ChIPSeqPeak>();
-            mspc.AddSample(0, sA);
-            mspc.AddSample(1, sB);
-
-            var config = new Config(ReplicateType.Biological, 1e-4, 1e-8, 1e-7, 1, 1F, MultipleIntersections.UseLowestPValue);
-
-            // Act
-            var res = mspc.Run(config);
-
-            // Assert
-            foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Stats[Attributes.Discarded] == 1);
-        }
-
-        [Fact]
         public void NoConfirmedAttributeForDiscardedPeaks()
         {
             // Arrange & Act
@@ -164,17 +105,6 @@ namespace Core.Tests.Base
             // Assert
             foreach (var s in res)
                 Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Confirmed).Count == 0);
-        }
-
-        [Fact]
-        public void CountNoConfirmedAttributeForDiscardedPeaks()
-        {
-            // Arrange & Act
-            var res = CreateStringentPeaksAndDiscardThem();
-
-            // Assert
-            foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Stats[Attributes.Confirmed] == 0);
         }
 
         [Fact]

--- a/Core.Tests/SetsAndAttributes/Stringent.cs
+++ b/Core.Tests/SetsAndAttributes/Stringent.cs
@@ -49,17 +49,6 @@ namespace Core.Tests.Base
         }
 
         [Fact]
-        public void CountStringentAttribute()
-        {
-            // Arrange & Act
-            var res = GenerateAndProcessStringentPeaks();
-
-            // Assert
-            foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Stats[Attributes.Stringent] == 1);
-        }
-
-        [Fact]
         public void StringentPeaksShouldNotHaveWeakAttribute()
         {
             // Arrange & Act
@@ -71,17 +60,6 @@ namespace Core.Tests.Base
         }
 
         [Fact]
-        public void CountStringentPeaksShouldNotHaveWeakAttribute()
-        {
-            // Arrange & Act
-            var res = GenerateAndProcessStringentPeaks();
-
-            // Assert
-            foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Stats[Attributes.Weak] == 0);
-        }
-
-        [Fact]
         public void StringentPeaksShouldNotHaveBackgroundAttribute()
         {
             // Arrange & Act
@@ -90,17 +68,6 @@ namespace Core.Tests.Base
             // Assert
             foreach (var s in res)
                 Assert.True(s.Value.Chromosomes[_chr].GetInitialClassifications(Attributes.Background).Count == 0);
-        }
-
-        [Fact]
-        public void CountStringentPeaksShouldNotHaveBackgroundAttribute()
-        {
-            // Arrange & Act
-            var res = GenerateAndProcessStringentPeaks();
-
-            // Assert
-            foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Stats[Attributes.Background] == 0);
         }
 
         [Fact]
@@ -125,30 +92,6 @@ namespace Core.Tests.Base
             // Assert
             foreach (var s in res)
                 Assert.True(s.Value.Chromosomes[_chr].GetInitialClassifications(Attributes.Stringent).Count == 1);
-        }
-
-        [Fact]
-        public void CountStringentNonOverlappingPeaks()
-        {
-            // Arrange
-            var sA = new BED<ChIPSeqPeak>();
-            sA.Add(new ChIPSeqPeak() { Left = 10, Right = 20, Value = 1e-9 }, _chr, _strand);
-
-            var sB = new BED<ChIPSeqPeak>();
-            sB.Add(new ChIPSeqPeak() { Left = 50, Right = 60, Value = 1e-12 }, _chr, _strand);
-
-            var mspc = new MSPC<ChIPSeqPeak>();
-            mspc.AddSample(0, sA);
-            mspc.AddSample(1, sB);
-
-            var config = new Config(ReplicateType.Biological, 1e-4, 1e-8, 1e-4, 2, 1F, MultipleIntersections.UseLowestPValue);
-
-            // Act
-            var res = mspc.Run(config);
-
-            // Assert
-            foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Stats[Attributes.Stringent] == 1);
         }
 
         [Fact]

--- a/Core.Tests/SetsAndAttributes/Weak.cs
+++ b/Core.Tests/SetsAndAttributes/Weak.cs
@@ -49,17 +49,6 @@ namespace Core.Tests.Base
         }
 
         [Fact]
-        public void CountWeakAttribute()
-        {
-            // Arrange & Act
-            var res = GenerateAndProcessWeakPeaks();
-
-            // Assert
-            foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Stats[Attributes.Weak] == 1);
-        }
-
-        [Fact]
         public void WeakPeaksShouldNotHaveStringentAttribute()
         {
             // Arrange & Act
@@ -71,17 +60,6 @@ namespace Core.Tests.Base
         }
 
         [Fact]
-        public void CountWeakPeaksShouldNotHaveStringentAttribute()
-        {
-            // Arrange & Act
-            var res = GenerateAndProcessWeakPeaks();
-
-            // Assert
-            foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Stats[Attributes.Stringent] == 0);
-        }
-
-        [Fact]
         public void WeakPeaksShouldNotHaveBackgroundAttribute()
         {
             // Arrange & Act
@@ -90,17 +68,6 @@ namespace Core.Tests.Base
             // Assert
             foreach (var s in res)
                 Assert.True(s.Value.Chromosomes[_chr].GetInitialClassifications(Attributes.Background).Count == 0);
-        }
-
-        [Fact]
-        public void CountWeakPeaksShouldNotHaveBackgroundAttribute()
-        {
-            // Arrange & Act
-            var res = GenerateAndProcessWeakPeaks();
-
-            // Assert
-            foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Stats[Attributes.Background] == 0);
         }
 
         [Fact]
@@ -125,30 +92,6 @@ namespace Core.Tests.Base
             // Assert
             foreach (var s in res)
                 Assert.True(s.Value.Chromosomes[_chr].GetInitialClassifications(Attributes.Weak).Count == 1);
-        }
-
-        [Fact]
-        public void CountWeakNonOverlappingPeaks()
-        {
-            // Arrange
-            var sA = new BED<ChIPSeqPeak>();
-            sA.Add(new ChIPSeqPeak() { Left = 10, Right = 20, Value = 1e-5 }, _chr, _strand);
-
-            var sB = new BED<ChIPSeqPeak>();
-            sB.Add(new ChIPSeqPeak() { Left = 50, Right = 60, Value = 1e-6 }, _chr, _strand);
-
-            var mspc = new MSPC<ChIPSeqPeak>();
-            mspc.AddSample(0, sA);
-            mspc.AddSample(1, sB);
-
-            var config = new Config(ReplicateType.Biological, 1e-4, 1e-8, 1e-4, 2, 1F, MultipleIntersections.UseLowestPValue);
-
-            // Act
-            var res = mspc.Run(config);
-
-            // Assert
-            foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Stats[Attributes.Weak] == 1);
         }
 
         [Fact]

--- a/Core/Model/Result.cs
+++ b/Core/Model/Result.cs
@@ -4,9 +4,7 @@
 
 using Genometric.GeUtilities.IGenomics;
 using Genometric.MSPC.Model;
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Genometric.MSPC.Core.Model
 {
@@ -23,14 +21,6 @@ namespace Genometric.MSPC.Core.Model
         public void AddChromosome(string chr)
         {
             Chromosomes.Add(chr, new Sets<I>());
-        }
-
-        public uint Stats(Attributes type)
-        {
-            uint rtv = 0;
-            foreach (var chr in Chromosomes)
-                rtv += chr.Value.Stats[type];
-            return rtv;
         }
     }
 }

--- a/Core/Model/Sets.cs
+++ b/Core/Model/Sets.cs
@@ -6,7 +6,6 @@ using Genometric.GeUtilities.IGenomics;
 using Genometric.MSPC.Core.Model;
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 
 namespace Genometric.MSPC.Model
@@ -14,16 +13,13 @@ namespace Genometric.MSPC.Model
     public class Sets<I>
         where I : IChIPSeqPeak, new()
     {
-        private readonly Dictionary<Attributes, uint> _stats;
+        private uint _fpCount;
+        private uint _tpCount;
         private Dictionary<Attributes, Dictionary<UInt64, I>> _setsInit { set; get; }
         private Dictionary<Attributes, Dictionary<UInt64, ProcessedPeak<I>>> _sets { set; get; }
 
         public Sets()
         {
-            _stats = new Dictionary<Attributes, uint>();
-            foreach (var att in Enum.GetValues(typeof(Attributes)).Cast<Attributes>())
-                _stats.Add(att, 0);
-
             _sets = new Dictionary<Attributes, Dictionary<ulong, ProcessedPeak<I>>>
             {
                 { Attributes.Confirmed, new Dictionary<ulong, ProcessedPeak<I>>() },
@@ -64,11 +60,7 @@ namespace Genometric.MSPC.Model
                 case Attributes.Confirmed:
                 case Attributes.Discarded:
                     if (!_sets[attribute].ContainsKey(peak.Source.HashKey))
-                    {
                         _sets[attribute].Add(peak.Source.HashKey, peak);
-                        foreach (var att in peak.Classification)
-                            _stats[att]++;
-                    }
                     break;
 
                 default:
@@ -88,19 +80,13 @@ namespace Genometric.MSPC.Model
                     case Attributes.Weak:
                     case Attributes.Background:
                         if (!_setsInit[attribute].ContainsKey(peak.Source.HashKey))
-                        {
                             _setsInit[attribute].Add(peak.Source.HashKey, peak.Source);
-                            _stats[attribute]++;
-                        }
                         break;
 
                     case Attributes.Confirmed:
                     case Attributes.Discarded:
                         if (!_sets[attribute].ContainsKey(peak.Source.HashKey))
-                        {
                             _sets[attribute].Add(peak.Source.HashKey, peak);
-                            _stats[attribute]++;
-                        }
                         break;
                 }
             }
@@ -155,19 +141,14 @@ namespace Genometric.MSPC.Model
             }
         }
 
-        public ImmutableDictionary<Attributes, uint> Stats
-        {
-            get { return _stats.ToImmutableDictionary(); }
-        }
-
         internal void SetFalsePositiveCount(uint value)
         {
-            _stats[Attributes.FalsePositive] = value;
+            _fpCount = value;
         }
 
         internal void SetTruePositiveCount(uint value)
         {
-            _stats[Attributes.TruePositive] = value;
+            _tpCount = value;
         }
     }
 }


### PR DESCRIPTION
The number of peaks with a given attribute can be retrieved from `_sets` property (which is exposed via `Get` method). Hence, keeping a count of attributes as a separate property is unnecessary and makes code more complicated and difficult to test. Therefore, this property of the `Sets` type is removed. 