### PR TITLE
Pre-processed and processed peaks are all stored as processed peaks

### DIFF
--- a/CLI/Export/ExporterBase.cs
+++ b/CLI/Export/ExporterBase.cs
@@ -135,14 +135,14 @@ namespace Genometric.MSPC.CLI.Exporter
 
                 foreach (var chr in data.Chromosomes)
                 {
-                    foreach (var item in chr.Value.GetInitialClassifications(Attributes.Stringent))
+                    foreach (var item in chr.Value.Get(Attributes.Stringent))
                     {
                         writter.WriteLine(
                             chr.Key + "\t" +
-                            item.Left.ToString() + "\t" +
-                            item.Right.ToString() + "\t" +
-                            item.Name + "\t" +
-                            ConvertPValue(item.Value));
+                            item.Source.Left.ToString() + "\t" +
+                            item.Source.Right.ToString() + "\t" +
+                            item.Source.Name + "\t" +
+                            ConvertPValue(item.Source.Value));
                     }
                 }
             }
@@ -157,14 +157,14 @@ namespace Genometric.MSPC.CLI.Exporter
 
                 foreach (var chr in data.Chromosomes)
                 {
-                    foreach (var item in chr.Value.GetInitialClassifications(Attributes.Weak))
+                    foreach (var item in chr.Value.Get(Attributes.Weak))
                     {
                         writter.WriteLine(
                             chr.Key + "\t" +
-                            item.Left.ToString() + "\t" +
-                            item.Right.ToString() + "\t" +
-                            item.Name + "\t" +
-                            ConvertPValue(item.Value));
+                            item.Source.Left.ToString() + "\t" +
+                            item.Source.Right.ToString() + "\t" +
+                            item.Source.Name + "\t" +
+                            ConvertPValue(item.Source.Value));
                     }
                 }
             }

--- a/Core.Tests/Example/Eg1.cs
+++ b/Core.Tests/Example/Eg1.cs
@@ -6,7 +6,6 @@ using Genometric.GeUtilities.IntervalParsers;
 using Genometric.GeUtilities.IntervalParsers.Model.Defaults;
 using Genometric.MSPC;
 using Genometric.MSPC.Model;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -113,20 +112,6 @@ namespace Core.Tests.Example
         [InlineData(ReplicateType.Technical, 3, 2, Attributes.Background, 0)]
         [InlineData(ReplicateType.Technical, 3, 2, Attributes.Weak, 1)]
         [InlineData(ReplicateType.Technical, 3, 2, Attributes.Stringent, 2)]
-        public void AssertSetsCountInitialSets(ReplicateType replicateType, byte c, uint sampleIndex, Attributes attribute, int expectedCount)
-        {
-            // Arrange
-            var mspc = InitializeMSPC();
-
-            // Act
-            var res = mspc.Run(new Config(replicateType, 1e-4, 1e-8, 1e-4, c, 1F, MultipleIntersections.UseLowestPValue));
-            var qres = res[sampleIndex].Chromosomes["chr1"].GetInitialClassifications(attribute);
-
-            // Assert
-            Assert.True(qres.Count == expectedCount);
-        }
-
-        [Theory]
         [InlineData(ReplicateType.Technical, 3, 0, Attributes.Confirmed, 1)]
         [InlineData(ReplicateType.Technical, 3, 0, Attributes.Discarded, 1)]
         [InlineData(ReplicateType.Technical, 3, 1, Attributes.Confirmed, 1)]

--- a/Core.Tests/SetsAndAttributes/BackgroundPeaks.cs
+++ b/Core.Tests/SetsAndAttributes/BackgroundPeaks.cs
@@ -45,7 +45,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].GetInitialClassifications(Attributes.Background).Count == 1);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Background).Count == 1);
         }
 
         [Fact]
@@ -57,8 +57,8 @@ namespace Core.Tests.Base
             // Assert
             foreach (var s in res)
                 Assert.True(
-                    s.Value.Chromosomes[_chr].GetInitialClassifications(Attributes.Weak).Count == 0 &&
-                    s.Value.Chromosomes[_chr].GetInitialClassifications(Attributes.Stringent).Count == 0 &&
+                    s.Value.Chromosomes[_chr].Get(Attributes.Weak).Count == 0 &&
+                    s.Value.Chromosomes[_chr].Get(Attributes.Stringent).Count == 0 &&
                     s.Value.Chromosomes[_chr].Get(Attributes.Confirmed).Count == 0 &&
                     s.Value.Chromosomes[_chr].Get(Attributes.Discarded).Count == 0 &&
                     s.Value.Chromosomes[_chr].Get(Attributes.TruePositive).Count == 0 &&
@@ -85,7 +85,7 @@ namespace Core.Tests.Base
             var res = mspc.Run(config);
 
             foreach(var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].GetInitialClassifications(Attributes.Background).Count == 1);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Background).Count == 1);
         }
 
         [Fact]
@@ -108,8 +108,8 @@ namespace Core.Tests.Base
             var res = mspc.Run(config);
 
             Assert.True(
-                res[0].Chromosomes[_chr].GetInitialClassifications(Attributes.Background).Count == 1 &&
-                res[1].Chromosomes[_chr].GetInitialClassifications(Attributes.Background).Count == 0);
+                res[0].Chromosomes[_chr].Get(Attributes.Background).Count == 1 &&
+                res[1].Chromosomes[_chr].Get(Attributes.Background).Count == 0);
         }
 
         [Fact]
@@ -136,8 +136,8 @@ namespace Core.Tests.Base
             // Assert
 
             Assert.True(
-                res[0].Chromosomes[_chr].GetInitialClassifications(Attributes.Background)[0].Equals(sAP) &&
-                res[1].Chromosomes[_chr].GetInitialClassifications(Attributes.Background)[0].Equals(sBP));
+                res[0].Chromosomes[_chr].Get(Attributes.Background)[0].Source.Equals(sAP) &&
+                res[1].Chromosomes[_chr].Get(Attributes.Background)[0].Source.Equals(sBP));
         }
     }
 }

--- a/Core.Tests/SetsAndAttributes/Stringent.cs
+++ b/Core.Tests/SetsAndAttributes/Stringent.cs
@@ -45,7 +45,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].GetInitialClassifications(Attributes.Stringent).Count == 1);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Stringent).Count == 1);
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].GetInitialClassifications(Attributes.Weak).Count == 0);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Weak).Count == 0);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].GetInitialClassifications(Attributes.Background).Count == 0);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Background).Count == 0);
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].GetInitialClassifications(Attributes.Stringent).Count == 1);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Stringent).Count == 1);
         }
 
         [Fact]
@@ -118,8 +118,8 @@ namespace Core.Tests.Base
             // Assert
 
             Assert.True(
-                res[0].Chromosomes[_chr].GetInitialClassifications(Attributes.Stringent)[0].Equals(sAP) &&
-                res[1].Chromosomes[_chr].GetInitialClassifications(Attributes.Stringent)[0].Equals(sBP));
+                res[0].Chromosomes[_chr].Get(Attributes.Stringent)[0].Source.Equals(sAP) &&
+                res[1].Chromosomes[_chr].Get(Attributes.Stringent)[0].Source.Equals(sBP));
         }
     }
 }

--- a/Core.Tests/SetsAndAttributes/Weak.cs
+++ b/Core.Tests/SetsAndAttributes/Weak.cs
@@ -45,7 +45,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].GetInitialClassifications(Attributes.Weak).Count == 1);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Weak).Count == 1);
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].GetInitialClassifications(Attributes.Stringent).Count == 0);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Stringent).Count == 0);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].GetInitialClassifications(Attributes.Background).Count == 0);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Background).Count == 0);
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].GetInitialClassifications(Attributes.Weak).Count == 1);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Weak).Count == 1);
         }
 
         [Fact]
@@ -118,8 +118,8 @@ namespace Core.Tests.Base
             // Assert
 
             Assert.True(
-                res[0].Chromosomes[_chr].GetInitialClassifications(Attributes.Weak)[0].Equals(sAP) &&
-                res[1].Chromosomes[_chr].GetInitialClassifications(Attributes.Weak)[0].Equals(sBP));
+                res[0].Chromosomes[_chr].Get(Attributes.Weak)[0].Source.Equals(sAP) &&
+                res[1].Chromosomes[_chr].Get(Attributes.Weak)[0].Source.Equals(sBP));
         }
     }
 }

--- a/Core/Model/ProcessedPeak.cs
+++ b/Core/Model/ProcessedPeak.cs
@@ -24,7 +24,10 @@ namespace Genometric.MSPC.Core.Model
         {
             XSquared = xSquared;
             SupportingPeaks = supportingPeaks;
-            RTP = ChiSquaredCache.ChiSqrdDistRTP(XSquared, 2 + (supportingPeaks.Count * 2));
+            if (double.IsNaN(xSquared))
+                RTP = double.NaN;
+            else
+                RTP = ChiSquaredCache.ChiSqrdDistRTP(XSquared, 2 + (supportingPeaks.Count * 2));
             Classification = new HashSet<Attributes>();
         }
 

--- a/Core/Model/Processor.cs
+++ b/Core/Model/Processor.cs
@@ -134,7 +134,7 @@ namespace Genometric.MSPC.Model
                                 attribute = Attributes.Weak;
                             else
                             {
-                                var pp = new ProcessedPeak<I>(peak, _xsqrd, new List<SupportingPeak<I>>());
+                                var pp = new ProcessedPeak<I>(peak, double.NaN, new List<SupportingPeak<I>>());
                                 pp.Classification.Add(Attributes.Background);
                                 _analysisResults[sample.Key].Chromosomes[chr.Key].Add(pp);
                                 continue;

--- a/Core/Model/Sets.cs
+++ b/Core/Model/Sets.cs
@@ -15,81 +15,27 @@ namespace Genometric.MSPC.Model
     {
         private uint _fpCount;
         private uint _tpCount;
-        private Dictionary<Attributes, Dictionary<UInt64, I>> _setsInit { set; get; }
         private Dictionary<Attributes, Dictionary<UInt64, ProcessedPeak<I>>> _sets { set; get; }
 
         public Sets()
         {
             _sets = new Dictionary<Attributes, Dictionary<ulong, ProcessedPeak<I>>>
             {
+                { Attributes.Stringent, new Dictionary<ulong, ProcessedPeak<I>>() },
+                { Attributes.Weak, new Dictionary<ulong, ProcessedPeak<I>>() },
+                { Attributes.Background, new Dictionary<ulong, ProcessedPeak<I>>() },
                 { Attributes.Confirmed, new Dictionary<ulong, ProcessedPeak<I>>() },
                 { Attributes.Discarded, new Dictionary<ulong, ProcessedPeak<I>>() },
                 { Attributes.TruePositive, new Dictionary<ulong, ProcessedPeak<I>>() },
                 { Attributes.FalsePositive, new Dictionary<ulong, ProcessedPeak<I>>() }
             };
-
-            _setsInit = new Dictionary<Attributes, Dictionary<UInt64, I>>
-            {
-                { Attributes.Stringent, new Dictionary<UInt64, I>() },
-                { Attributes.Weak, new Dictionary<UInt64, I>() },
-                { Attributes.Background, new Dictionary<UInt64, I>() }
-            };
-        }
-
-        public void Add(I peak, Attributes attribute)
-        {
-            switch (attribute)
-            {
-                case Attributes.Stringent:
-                case Attributes.Weak:
-                case Attributes.Background:
-                    _setsInit[attribute].Add(peak.HashKey, peak);
-                    break;
-
-                default:
-                    throw new ArgumentException(
-                    String.Format("Invalid attribute; accepted values are: {0}, {1}, and {2}.",
-                    Attributes.Stringent.ToString(), Attributes.Weak.ToString(), Attributes.Background.ToString()));
-            }
-        }
-
-        public void Add(ProcessedPeak<I> peak, Attributes attribute)
-        {
-            switch (attribute)
-            {
-                case Attributes.Confirmed:
-                case Attributes.Discarded:
-                    if (!_sets[attribute].ContainsKey(peak.Source.HashKey))
-                        _sets[attribute].Add(peak.Source.HashKey, peak);
-                    break;
-
-                default:
-                    throw new ArgumentException(
-                    String.Format("Invalid attribute; accepted values are: {0} and {1}.",
-                    Attributes.Confirmed.ToString(), Attributes.Discarded.ToString()));
-            }
         }
 
         public void Add(ProcessedPeak<I> peak)
         {
-            foreach(var attribute in peak.Classification)
-            {
-                switch(attribute)
-                {
-                    case Attributes.Stringent:
-                    case Attributes.Weak:
-                    case Attributes.Background:
-                        if (!_setsInit[attribute].ContainsKey(peak.Source.HashKey))
-                            _setsInit[attribute].Add(peak.Source.HashKey, peak.Source);
-                        break;
-
-                    case Attributes.Confirmed:
-                    case Attributes.Discarded:
-                        if (!_sets[attribute].ContainsKey(peak.Source.HashKey))
-                            _sets[attribute].Add(peak.Source.HashKey, peak);
-                        break;
-                }
-            }
+            foreach (var attribute in peak.Classification)
+                if (!_sets[attribute].ContainsKey(peak.Source.HashKey))
+                    _sets[attribute].Add(peak.Source.HashKey, peak);
         }
 
         public List<ProcessedPeak<I>> Get(Attributes attributes)
@@ -99,46 +45,12 @@ namespace Genometric.MSPC.Model
 
         public bool Contains(Attributes attribute, UInt64 hashkey)
         {
-            switch (attribute)
-            {
-                case Attributes.Stringent:
-                case Attributes.Weak:
-                case Attributes.Background:
-                    return _setsInit[attribute].ContainsKey(0);
-
-                default:
-                    return _sets[attribute].ContainsKey(hashkey);
-            }
+            return _sets[attribute].ContainsKey(hashkey);
         }
 
         internal bool Remove(Attributes attribute, UInt64 hashkey)
         {
-            switch (attribute)
-            {
-                case Attributes.Stringent:
-                case Attributes.Weak:
-                case Attributes.Background:
-                    return _setsInit[attribute].Remove(0);
-
-                default:
-                    return _sets[attribute].Remove(hashkey);
-            }
-        }
-
-        public IList<I> GetInitialClassifications(Attributes attribute)
-        {
-            switch (attribute)
-            {
-                case Attributes.Stringent:
-                case Attributes.Weak:
-                case Attributes.Background:
-                    return _setsInit[attribute].Values.ToList();
-
-                default:
-                    throw new ArgumentException(
-                    String.Format("Invalid attribute; accepted values are: {0}, {1}, and {2}.",
-                    Attributes.Stringent.ToString(), Attributes.Weak.ToString(), Attributes.Background.ToString()));
-            }
+            return _sets[attribute].Remove(hashkey);
         }
 
         internal void SetFalsePositiveCount(uint value)


### PR DESCRIPTION
The `Sets` type has two properties `_sets` and `_setsInit`, which are used to store processed (i.e., peaks with `Confirmed`, `Stringent`, `True-Positive`, and `False-Positive` attributes) and pre-processed (i.e., peaks with `Stringent`, `Weak` and `Background` attributes) peaks respectively. This PR stores all peaks (both processed and pre-processed) in the `_sets` property, hence removes `_setsInit`. 