### PR TITLE
Store all the peaks in a single data structure

### DIFF
--- a/Core.Tests/Base/ColocalizationCount.cs
+++ b/Core.Tests/Base/ColocalizationCount.cs
@@ -35,7 +35,7 @@ namespace Core.Tests.Base
             var res = mspc.Run(config);
 
             // Assert
-            Assert.True(new[] { res[0].Chromosomes["chr1"].Get(Attributes.Confirmed).Count, res[1].Chromosomes["chr1"].Get(Attributes.Confirmed).Count }.All(x => x == expected));
+            Assert.True(new[] { res[0].Chromosomes["chr1"].Get(Attributes.Confirmed).Count(), res[1].Chromosomes["chr1"].Get(Attributes.Confirmed).Count() }.All(x => x == expected));
         }
 
         [Theory]
@@ -60,7 +60,7 @@ namespace Core.Tests.Base
             var res = mspc.Run(config);
 
             // Assert
-            Assert.True(new[] { res[0].Chromosomes["chr1"].Get(Attributes.Confirmed).Count, res[1].Chromosomes["chr1"].Get(Attributes.Confirmed).Count }.All(x => x == expected));
+            Assert.True(new[] { res[0].Chromosomes["chr1"].Get(Attributes.Confirmed).Count(), res[1].Chromosomes["chr1"].Get(Attributes.Confirmed).Count() }.All(x => x == expected));
         }
 
         [Theory]
@@ -90,7 +90,7 @@ namespace Core.Tests.Base
             var res = mspc.Run(config);
 
             // Assert
-            Assert.True(new[] { res[0].Chromosomes["chr1"].Get(Attributes.Confirmed).Count, res[1].Chromosomes["chr1"].Get(Attributes.Confirmed).Count, res[2].Chromosomes["chr1"].Get(Attributes.Confirmed).Count }.All(x => x == expected));
+            Assert.True(new[] { res[0].Chromosomes["chr1"].Get(Attributes.Confirmed).Count(), res[1].Chromosomes["chr1"].Get(Attributes.Confirmed).Count(), res[2].Chromosomes["chr1"].Get(Attributes.Confirmed).Count() }.All(x => x == expected));
         }
 
         [Theory]
@@ -120,7 +120,7 @@ namespace Core.Tests.Base
             var res = mspc.Run(config);
 
             // Assert
-            Assert.True(new[] { res[0].Chromosomes["chr1"].Get(Attributes.Confirmed).Count, res[1].Chromosomes["chr1"].Get(Attributes.Confirmed).Count, res[2].Chromosomes["chr1"].Get(Attributes.Confirmed).Count }.All(x => x == expected));
+            Assert.True(new[] { res[0].Chromosomes["chr1"].Get(Attributes.Confirmed).Count(), res[1].Chromosomes["chr1"].Get(Attributes.Confirmed).Count(), res[2].Chromosomes["chr1"].Get(Attributes.Confirmed).Count() }.All(x => x == expected));
         }
 
         [Theory]
@@ -150,7 +150,7 @@ namespace Core.Tests.Base
             var res = mspc.Run(config);
 
             // Assert
-            Assert.True(new[] { res[0].Chromosomes["chr1"].Get(Attributes.Confirmed).Count, res[1].Chromosomes["chr1"].Get(Attributes.Confirmed).Count, res[2].Chromosomes["chr1"].Get(Attributes.Confirmed).Count }.All(x => x == expected));
+            Assert.True(new[] { res[0].Chromosomes["chr1"].Get(Attributes.Confirmed).Count(), res[1].Chromosomes["chr1"].Get(Attributes.Confirmed).Count(), res[2].Chromosomes["chr1"].Get(Attributes.Confirmed).Count() }.All(x => x == expected));
         }
 
         [Fact]
@@ -178,7 +178,7 @@ namespace Core.Tests.Base
             var res = mspc.Run(config);
 
             // Assert
-            Assert.True(res[0].Chromosomes["chr1"].Get(Attributes.Confirmed).Count == 0);
+            Assert.True(res[0].Chromosomes["chr1"].Get(Attributes.Confirmed).Count() == 0);
         }
     }
 }

--- a/Core.Tests/Example/Eg1.cs
+++ b/Core.Tests/Example/Eg1.cs
@@ -134,7 +134,7 @@ namespace Core.Tests.Example
             var qres = res[sampleIndex].Chromosomes["chr1"].Get(attribute);
 
             // Assert
-            Assert.True(qres.Count == expectedCount);
+            Assert.True(qres.Count() == expectedCount);
         }
     }
 }

--- a/Core.Tests/SetsAndAttributes/BackgroundPeaks.cs
+++ b/Core.Tests/SetsAndAttributes/BackgroundPeaks.cs
@@ -8,6 +8,7 @@ using Genometric.MSPC;
 using Genometric.MSPC.Core.Model;
 using Genometric.MSPC.Model;
 using System.Collections.ObjectModel;
+using System.Linq;
 using Xunit;
 
 namespace Core.Tests.Base
@@ -45,7 +46,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Background).Count == 1);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Background).Count() == 1);
         }
 
         [Fact]
@@ -57,12 +58,12 @@ namespace Core.Tests.Base
             // Assert
             foreach (var s in res)
                 Assert.True(
-                    s.Value.Chromosomes[_chr].Get(Attributes.Weak).Count == 0 &&
-                    s.Value.Chromosomes[_chr].Get(Attributes.Stringent).Count == 0 &&
-                    s.Value.Chromosomes[_chr].Get(Attributes.Confirmed).Count == 0 &&
-                    s.Value.Chromosomes[_chr].Get(Attributes.Discarded).Count == 0 &&
-                    s.Value.Chromosomes[_chr].Get(Attributes.TruePositive).Count == 0 &&
-                    s.Value.Chromosomes[_chr].Get(Attributes.FalsePositive).Count == 0);
+                    s.Value.Chromosomes[_chr].Get(Attributes.Weak).Count() == 0 &&
+                    s.Value.Chromosomes[_chr].Get(Attributes.Stringent).Count() == 0 &&
+                    s.Value.Chromosomes[_chr].Get(Attributes.Confirmed).Count() == 0 &&
+                    s.Value.Chromosomes[_chr].Get(Attributes.Discarded).Count() == 0 &&
+                    s.Value.Chromosomes[_chr].Get(Attributes.TruePositive).Count() == 0 &&
+                    s.Value.Chromosomes[_chr].Get(Attributes.FalsePositive).Count() == 0);
         }
 
         [Fact]
@@ -85,7 +86,7 @@ namespace Core.Tests.Base
             var res = mspc.Run(config);
 
             foreach(var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Background).Count == 1);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Background).Count() == 1);
         }
 
         [Fact]
@@ -108,8 +109,8 @@ namespace Core.Tests.Base
             var res = mspc.Run(config);
 
             Assert.True(
-                res[0].Chromosomes[_chr].Get(Attributes.Background).Count == 1 &&
-                res[1].Chromosomes[_chr].Get(Attributes.Background).Count == 0);
+                res[0].Chromosomes[_chr].Get(Attributes.Background).Count() == 1 &&
+                res[1].Chromosomes[_chr].Get(Attributes.Background).Count() == 0);
         }
 
         [Fact]
@@ -136,8 +137,8 @@ namespace Core.Tests.Base
             // Assert
 
             Assert.True(
-                res[0].Chromosomes[_chr].Get(Attributes.Background)[0].Source.Equals(sAP) &&
-                res[1].Chromosomes[_chr].Get(Attributes.Background)[0].Source.Equals(sBP));
+                res[0].Chromosomes[_chr].Get(Attributes.Background).ToList()[0].Source.Equals(sAP) &&
+                res[1].Chromosomes[_chr].Get(Attributes.Background).ToList()[0].Source.Equals(sBP));
         }
     }
 }

--- a/Core.Tests/SetsAndAttributes/Confirmed.cs
+++ b/Core.Tests/SetsAndAttributes/Confirmed.cs
@@ -8,6 +8,7 @@ using Genometric.MSPC;
 using Genometric.MSPC.Core.Model;
 using Genometric.MSPC.Model;
 using System.Collections.ObjectModel;
+using System.Linq;
 using Xunit;
 
 namespace Core.Tests.Base
@@ -45,7 +46,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Confirmed).Count == 1);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Confirmed).Count() == 1);
         }
 
         [Fact]
@@ -69,7 +70,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Confirmed).Count == 1);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Confirmed).Count() == 1);
         }
 
         [Fact]
@@ -93,7 +94,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Confirmed).Count == 1);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Confirmed).Count() == 1);
         }
 
         [Fact]
@@ -104,7 +105,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Discarded).Count == 0);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Discarded).Count() == 0);
         }
 
         [Fact]
@@ -131,8 +132,8 @@ namespace Core.Tests.Base
             // Assert
 
             Assert.True(
-                res[0].Chromosomes[_chr].Get(Attributes.Confirmed)[0].Source.Equals(sAP) &&
-                res[1].Chromosomes[_chr].Get(Attributes.Confirmed)[0].Source.Equals(sBP));
+                res[0].Chromosomes[_chr].Get(Attributes.Confirmed).ToList()[0].Source.Equals(sAP) &&
+                res[1].Chromosomes[_chr].Get(Attributes.Confirmed).ToList()[0].Source.Equals(sBP));
         }
     }
 }

--- a/Core.Tests/SetsAndAttributes/Discarded.cs
+++ b/Core.Tests/SetsAndAttributes/Discarded.cs
@@ -8,6 +8,7 @@ using Genometric.MSPC;
 using Genometric.MSPC.Core.Model;
 using Genometric.MSPC.Model;
 using System.Collections.ObjectModel;
+using System.Linq;
 using Xunit;
 
 namespace Core.Tests.Base
@@ -45,7 +46,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Discarded).Count == 1);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Discarded).Count() == 1);
         }
 
         [Fact]
@@ -69,7 +70,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Discarded).Count == 1);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Discarded).Count() == 1);
         }
 
         [Fact]
@@ -93,7 +94,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Discarded).Count == 1);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Discarded).Count() == 1);
         }
 
         [Fact]
@@ -104,7 +105,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Confirmed).Count == 0);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Confirmed).Count() == 0);
         }
 
         [Fact]
@@ -131,8 +132,8 @@ namespace Core.Tests.Base
             // Assert
 
             Assert.True(
-                res[0].Chromosomes[_chr].Get(Attributes.Discarded)[0].Source.Equals(sAP) &&
-                res[1].Chromosomes[_chr].Get(Attributes.Discarded)[0].Source.Equals(sBP));
+                res[0].Chromosomes[_chr].Get(Attributes.Discarded).ToList()[0].Source.Equals(sAP) &&
+                res[1].Chromosomes[_chr].Get(Attributes.Discarded).ToList()[0].Source.Equals(sBP));
         }
     }
 }

--- a/Core.Tests/SetsAndAttributes/Stringent.cs
+++ b/Core.Tests/SetsAndAttributes/Stringent.cs
@@ -8,6 +8,7 @@ using Genometric.MSPC;
 using Genometric.MSPC.Core.Model;
 using Genometric.MSPC.Model;
 using System.Collections.ObjectModel;
+using System.Linq;
 using Xunit;
 
 namespace Core.Tests.Base
@@ -45,7 +46,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Stringent).Count == 1);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Stringent).Count() == 1);
         }
 
         [Fact]
@@ -56,7 +57,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Weak).Count == 0);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Weak).Count() == 0);
         }
 
         [Fact]
@@ -67,7 +68,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Background).Count == 0);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Background).Count() == 0);
         }
 
         [Fact]
@@ -91,7 +92,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Stringent).Count == 1);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Stringent).Count() == 1);
         }
 
         [Fact]
@@ -118,8 +119,8 @@ namespace Core.Tests.Base
             // Assert
 
             Assert.True(
-                res[0].Chromosomes[_chr].Get(Attributes.Stringent)[0].Source.Equals(sAP) &&
-                res[1].Chromosomes[_chr].Get(Attributes.Stringent)[0].Source.Equals(sBP));
+                res[0].Chromosomes[_chr].Get(Attributes.Stringent).ToList()[0].Source.Equals(sAP) &&
+                res[1].Chromosomes[_chr].Get(Attributes.Stringent).ToList()[0].Source.Equals(sBP));
         }
     }
 }

--- a/Core.Tests/SetsAndAttributes/Weak.cs
+++ b/Core.Tests/SetsAndAttributes/Weak.cs
@@ -8,6 +8,7 @@ using Genometric.MSPC;
 using Genometric.MSPC.Core.Model;
 using Genometric.MSPC.Model;
 using System.Collections.ObjectModel;
+using System.Linq;
 using Xunit;
 
 namespace Core.Tests.Base
@@ -45,7 +46,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Weak).Count == 1);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Weak).Count() == 1);
         }
 
         [Fact]
@@ -56,7 +57,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Stringent).Count == 0);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Stringent).Count() == 0);
         }
 
         [Fact]
@@ -67,7 +68,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Background).Count == 0);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Background).Count() == 0);
         }
 
         [Fact]
@@ -91,7 +92,7 @@ namespace Core.Tests.Base
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Weak).Count == 1);
+                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Weak).Count() == 1);
         }
 
         [Fact]
@@ -118,8 +119,8 @@ namespace Core.Tests.Base
             // Assert
 
             Assert.True(
-                res[0].Chromosomes[_chr].Get(Attributes.Weak)[0].Source.Equals(sAP) &&
-                res[1].Chromosomes[_chr].Get(Attributes.Weak)[0].Source.Equals(sBP));
+                res[0].Chromosomes[_chr].Get(Attributes.Weak).ToList()[0].Source.Equals(sAP) &&
+                res[1].Chromosomes[_chr].Get(Attributes.Weak).ToList()[0].Source.Equals(sBP));
         }
     }
 }

--- a/Core/Model/UpdateProcessedPeak.cs
+++ b/Core/Model/UpdateProcessedPeak.cs
@@ -3,26 +3,23 @@
 // See the LICENSE file in the project root for more information.
 
 using Genometric.GeUtilities.IGenomics;
-using Genometric.MSPC.Model;
+using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace Genometric.MSPC.Core.Model
 {
-    public class Result<I>
+    internal static class UpdateProcessedPeak<I>
         where I : IChIPSeqPeak, new()
     {
-        private ReplicateType _replicateType;
-        public Dictionary<string, Sets<I>> Chromosomes { set; get; }
-
-        internal Result(ReplicateType replicateType)
+        public static ProcessedPeak<I> AsTecRep(ProcessedPeak<I> input)
         {
-            _replicateType = replicateType;
-            Chromosomes = new Dictionary<string, Sets<I>>();
+            return input;
         }
 
-        public void AddChromosome(string chr, int capacity)
+        public static ProcessedPeak<I> AsBioRep(ProcessedPeak<I> input)
         {
-            Chromosomes.Add(chr, new Sets<I>(capacity, _replicateType));
+            return input;
         }
     }
 }


### PR DESCRIPTION
MSPC stores separately `ProcessedPeaks` with different attributes. For instance, it stores `Confirmed` peaks in a different list (i.e., `_sets[Attributes.Confirmed]`) than `Discarded` peaks (i.e., `_sets[Attributes.Discarded]`). To ensure that a single peaks is either `Confirmed` or `Discarded` (no peak is both `Confirmed` and `Discarded`), MSPC post-processed `_sets` in `ProcessIntermediaSets` method of the `Process` class. 

However, the code the relation between `Classifications` property of processed peaks and separated list, is confusing and cumbersome to implement/debug and test. Therefore, this PR creates a single dictionary, called `_peaks` that stores all the processed peaks in a single data structure regardless of attributes of the processed peaks. 

Some other advantages of this method is code simplicity and no need for post-processing sets (i.e., `ProcessIntermediaSets`). The downside is to get a list of peaks with a certain attribute (e.g., _get all the confirmed peaks_) is implemented querying the values of KVP in `_peaks` dictionary leveraging LINQ, which may not be as efficient as having peaks in separated lists. Also, counting the number of peaks with a certain attribute requires a linear scan on the values of KVPs in the `_peaks`.  