### PR TITLE
Update CommandLineOptions class leveraging `Microsoft.Extensions.CommandLineUtils` and add required unit tests. 

### DIFF
--- a/CLI.Tests/CLI.Tests.csproj
+++ b/CLI.Tests/CLI.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+
+    <AssemblyName>Genometric.MSPC.CLI.Tests</AssemblyName>
+
+    <RootNamespace>Genometric.MSPC.CLI.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CLI\CLI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CLI.Tests/CLIOptions.cs
+++ b/CLI.Tests/CLIOptions.cs
@@ -40,6 +40,24 @@ namespace Genometric.MSPC.CLI.Tests
             return builder.ToString();
         }
 
+        [Theory]
+        [InlineData("rep_1.bed", "rep_2.bed", "rep_3.bed", 3)]
+        [InlineData("rep_1.bed", "rep_2.bed", null, 2)]
+        [InlineData("C:\\TestPath\\replicate_1", "C:\\AnotherTestPath\\replicate_2", "C:\\YetAnotherTestPath\\replicate_3", 3)]
+        public void ReadInput(string rep1, string rep2, string rep3, int validInputCount)
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            var po = options.Parse(GenerateShortNameArguments(rep1: rep1, rep2: rep2, rep3: rep3).Split(' '));
+
+            // Assert
+            Assert.True(options.Input.Count == validInputCount);
+            Assert.True(options.Input[0] == rep1);
+            Assert.True(options.Input[1] == rep2);
+            if (rep3 != null)
+                Assert.True(options.Input[2] == rep3);
+        }
+
         [Fact]
         public void ReadTauS()
         {

--- a/CLI.Tests/CLIOptions.cs
+++ b/CLI.Tests/CLIOptions.cs
@@ -19,24 +19,24 @@ namespace Genometric.MSPC.CLI.Tests
         private const double _gamma = 1E-12;
         private const float _alpha = 0.0005F;
         private const byte _c = 2;
-        private const MultipleIntersections _m = MultipleIntersections.UseLowestPValue;
+        private const string _m = "lowest";
         private const ReplicateType _r = ReplicateType.Biological;
 
         private string GenerateShortNameArguments(
             string rep1 = _rep1, string rep2 = _rep2, string rep3 = _rep3, double tauW = _tauW, double tauS = _tauS,
-            double gamma = _gamma, float alpha = _alpha, byte c = _c, MultipleIntersections m = _m, ReplicateType r = _r)
+            double gamma = _gamma, float alpha = _alpha, byte c = _c, string m = _m, ReplicateType r = _r)
         {
             var builder = new StringBuilder();
             if (rep1 != null) builder.Append("-i " + rep1 + " ");
             if (rep2 != null) builder.Append("-i " + rep2 + " ");
             if (rep3 != null) builder.Append("-i " + rep3 + " ");
-            if (Double.IsNaN(tauW)) builder.Append("-w " + tauW + " ");
-            if (Double.IsNaN(tauS)) builder.Append("-s " + tauS + " ");
-            if (Double.IsNaN(gamma)) builder.Append("-g " + gamma + " ");
-            if (float.IsNaN(alpha)) builder.Append("-a " + alpha + " ");
+            if (!Double.IsNaN(tauW)) builder.Append("-w " + tauW + " ");
+            if (!Double.IsNaN(tauS)) builder.Append("-s " + tauS + " ");
+            if (!Double.IsNaN(gamma)) builder.Append("-g " + gamma + " ");
+            if (!float.IsNaN(alpha)) builder.Append("-a " + alpha + " ");
             builder.Append("-c " + c + " ");
             builder.Append("-m " + m + " ");
-            builder.Append("-r " + r + " ");
+            builder.Append("-r " + r);
             return builder.ToString();
         }
 

--- a/CLI.Tests/CLIOptions.cs
+++ b/CLI.Tests/CLIOptions.cs
@@ -162,6 +162,20 @@ namespace Genometric.MSPC.CLI.Tests
         }
 
         [Fact]
+        public void NoExceptionIfOnlyRequiredArgumentsAreGiven()
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            var po = options.Parse("-i rep1.bed -i rep2.bed -r bio -w 1E-2 -s 1E-8".Split(' '));
+
+            // Assert
+            Assert.True(options.Input.Count == 2);
+            Assert.True(po.ReplicateType == ReplicateType.Biological);
+            Assert.True(po.TauW == 1E-2);
+            Assert.True(po.TauS == 1E-8);
+        }
+
+        [Fact]
         public void ThrowExceptionForMissingInput()
         {
             // Arrange & Act

--- a/CLI.Tests/CLIOptions.cs
+++ b/CLI.Tests/CLIOptions.cs
@@ -20,11 +20,11 @@ namespace Genometric.MSPC.CLI.Tests
         private const float _alpha = 0.0005F;
         private const byte _c = 2;
         private const string _m = "lowest";
-        private const ReplicateType _r = ReplicateType.Biological;
+        private const string _r = "bio";
 
         private string GenerateShortNameArguments(
             string rep1 = _rep1, string rep2 = _rep2, string rep3 = _rep3, double tauW = _tauW, double tauS = _tauS,
-            double gamma = _gamma, float alpha = _alpha, byte c = _c, string m = _m, ReplicateType r = _r)
+            double gamma = _gamma, float alpha = _alpha, byte c = _c, string m = _m, string r = _r)
         {
             var builder = new StringBuilder();
             if (rep1 != null) builder.Append("-i " + rep1 + " ");
@@ -101,6 +101,64 @@ namespace Genometric.MSPC.CLI.Tests
 
             // Assert
             Assert.True(po.Gamma == gamma);
+        }
+
+        [Theory]
+        [InlineData(_alpha)]
+        [InlineData(1)]
+        [InlineData(0)]
+        [InlineData(1.1E-53)]
+        public void ReadAlpha(float alpha)
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            var po = options.Parse(GenerateShortNameArguments(alpha: alpha).Split(' '));
+
+            // Assert
+            Assert.True(po.Alpha == alpha);
+        }
+
+        [Theory]
+        [InlineData(_c)]
+        [InlineData(1)]
+        [InlineData(5)]
+        public void ReadC(byte c)
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            var po = options.Parse(GenerateShortNameArguments(c: c).Split(' '));
+
+            // Assert
+            Assert.True(po.C == c);
+        }
+
+        [Theory]
+        [InlineData("lowest", MultipleIntersections.UseLowestPValue)]
+        [InlineData("LowEST", MultipleIntersections.UseLowestPValue)]
+        [InlineData("highest", MultipleIntersections.UseHighestPValue)]
+        public void ReadM(string m, MultipleIntersections expectedValue)
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            var po = options.Parse(GenerateShortNameArguments(m: m).Split(' '));
+
+            // Assert
+            Assert.True(po.MultipleIntersections == expectedValue);
+        }
+
+        [Theory]
+        [InlineData("bio", ReplicateType.Biological)]
+        [InlineData("tec", ReplicateType.Technical)]
+        [InlineData("BioloGicAl", ReplicateType.Biological)]
+        [InlineData("Technical", ReplicateType.Technical)]
+        public void ReadR(string r, ReplicateType expectedValue)
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            var po = options.Parse(GenerateShortNameArguments(r: r).Split(' '));
+
+            // Assert
+            Assert.True(po.ReplicateType == expectedValue);
         }
     }
 }

--- a/CLI.Tests/CLIOptions.cs
+++ b/CLI.Tests/CLIOptions.cs
@@ -58,15 +58,49 @@ namespace Genometric.MSPC.CLI.Tests
                 Assert.True(options.Input[2] == rep3);
         }
 
-        [Fact]
-        public void ReadTauS()
+        [Theory]
+        [InlineData(_tauS)]
+        [InlineData(1)]
+        [InlineData(0)]
+        [InlineData(1.1E-53)]
+        public void ReadTauS(double tauS)
         {
             // Arrange & Act
             var options = new CommandLineOptions();
-            var po = options.Parse(GenerateShortNameArguments().Split(' '));
+            var po = options.Parse(GenerateShortNameArguments(tauS: tauS).Split(' '));
 
             // Assert
-            Assert.True(po.TauS == _tauS);
+            Assert.True(po.TauS == tauS);
+        }
+
+        [Theory]
+        [InlineData(_tauW)]
+        [InlineData(1)]
+        [InlineData(0)]
+        [InlineData(1.1E-53)]
+        public void ReadTauW(double tauW)
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            var po = options.Parse(GenerateShortNameArguments(tauW: tauW).Split(' '));
+
+            // Assert
+            Assert.True(po.TauW == tauW);
+        }
+
+        [Theory]
+        [InlineData(_gamma)]
+        [InlineData(1)]
+        [InlineData(0)]
+        [InlineData(1.1E-53)]
+        public void ReadGamma(double gamma)
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            var po = options.Parse(GenerateShortNameArguments(gamma: gamma).Split(' '));
+
+            // Assert
+            Assert.True(po.Gamma == gamma);
         }
     }
 }

--- a/CLI.Tests/CLIOptions.cs
+++ b/CLI.Tests/CLIOptions.cs
@@ -160,5 +160,16 @@ namespace Genometric.MSPC.CLI.Tests
             // Assert
             Assert.True(po.ReplicateType == expectedValue);
         }
+
+        [Fact]
+        public void ThrowExceptionForMissingInput()
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            string[] arguments = "-w 1E-2 -s 1E-8 -g 1E-16 -r bio".Split(' ');
+
+            // Assert
+            Assert.Throws<ArgumentException>(() => options.Parse(arguments));
+        }
     }
 }

--- a/CLI.Tests/CLIOptions.cs
+++ b/CLI.Tests/CLIOptions.cs
@@ -1,0 +1,54 @@
+// Licensed to the Genometric organization (https://github.com/Genometric) under one or more agreements.
+// The Genometric organization licenses this file to you under the GNU General Public License v3.0 (GPLv3).
+// See the LICENSE file in the project root for more information.
+
+using Genometric.MSPC.Model;
+using System;
+using System.Text;
+using Xunit;
+
+namespace Genometric.MSPC.CLI.Tests
+{
+    public class CLIOptions
+    {
+        private const string _rep1 = "replicate_1.bed";
+        private const string _rep2 = "replicate_2.bed";
+        private const string _rep3 = "replicate_3.bed";
+        private const double _tauW = 1E-2;
+        private const double _tauS = 1E-9;
+        private const double _gamma = 1E-12;
+        private const float _alpha = 0.0005F;
+        private const byte _c = 2;
+        private const MultipleIntersections _m = MultipleIntersections.UseLowestPValue;
+        private const ReplicateType _r = ReplicateType.Biological;
+
+        private string GenerateShortNameArguments(
+            string rep1 = _rep1, string rep2 = _rep2, string rep3 = _rep3, double tauW = _tauW, double tauS = _tauS,
+            double gamma = _gamma, float alpha = _alpha, byte c = _c, MultipleIntersections m = _m, ReplicateType r = _r)
+        {
+            var builder = new StringBuilder();
+            if (rep1 != null) builder.Append("-i " + rep1);
+            if (rep2 != null) builder.Append("-i " + rep2);
+            if (rep3 != null) builder.Append("-i " + rep3);
+            if (Double.IsNaN(tauW)) builder.Append("-w " + tauW);
+            if (Double.IsNaN(tauS)) builder.Append("-s " + tauS);
+            if (Double.IsNaN(gamma)) builder.Append("-g " + gamma);
+            if (float.IsNaN(alpha)) builder.Append("-a " + alpha);
+            builder.Append("-c " + c);
+            builder.Append("-m " + m);
+            builder.Append("-r " + r);
+            return builder.ToString();
+        }
+
+        [Fact]
+        public void ReadTauS()
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            var po = options.Parse(GenerateShortNameArguments().Split(' '));
+
+            // Assert
+            Assert.True(po.TauS == _tauS);
+        }
+    }
+}

--- a/CLI.Tests/CLIOptions.cs
+++ b/CLI.Tests/CLIOptions.cs
@@ -176,6 +176,20 @@ namespace Genometric.MSPC.CLI.Tests
         }
 
         [Fact]
+        public void UseDefaultValuesForOptionalArguments()
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            var po = options.Parse("-i rep1.bed -i rep2.bed -r bio -w 1E-2 -s 1E-8".Split(' '));
+
+            // Assert
+            Assert.True(po.Gamma == -1);
+            Assert.True(po.Alpha == 0.05F);
+            Assert.True(po.C == 1);
+            Assert.True(po.MultipleIntersections == MultipleIntersections.UseLowestPValue);
+        }
+
+        [Fact]
         public void ThrowExceptionForMissingInput()
         {
             // Arrange & Act

--- a/CLI.Tests/CLIOptions.cs
+++ b/CLI.Tests/CLIOptions.cs
@@ -27,16 +27,16 @@ namespace Genometric.MSPC.CLI.Tests
             double gamma = _gamma, float alpha = _alpha, byte c = _c, MultipleIntersections m = _m, ReplicateType r = _r)
         {
             var builder = new StringBuilder();
-            if (rep1 != null) builder.Append("-i " + rep1);
-            if (rep2 != null) builder.Append("-i " + rep2);
-            if (rep3 != null) builder.Append("-i " + rep3);
-            if (Double.IsNaN(tauW)) builder.Append("-w " + tauW);
-            if (Double.IsNaN(tauS)) builder.Append("-s " + tauS);
-            if (Double.IsNaN(gamma)) builder.Append("-g " + gamma);
-            if (float.IsNaN(alpha)) builder.Append("-a " + alpha);
-            builder.Append("-c " + c);
-            builder.Append("-m " + m);
-            builder.Append("-r " + r);
+            if (rep1 != null) builder.Append("-i " + rep1 + " ");
+            if (rep2 != null) builder.Append("-i " + rep2 + " ");
+            if (rep3 != null) builder.Append("-i " + rep3 + " ");
+            if (Double.IsNaN(tauW)) builder.Append("-w " + tauW + " ");
+            if (Double.IsNaN(tauS)) builder.Append("-s " + tauS + " ");
+            if (Double.IsNaN(gamma)) builder.Append("-g " + gamma + " ");
+            if (float.IsNaN(alpha)) builder.Append("-a " + alpha + " ");
+            builder.Append("-c " + c + " ");
+            builder.Append("-m " + m + " ");
+            builder.Append("-r " + r + " ");
             return builder.ToString();
         }
 

--- a/CLI.Tests/CLIOptions.cs
+++ b/CLI.Tests/CLIOptions.cs
@@ -48,7 +48,7 @@ namespace Genometric.MSPC.CLI.Tests
         {
             // Arrange & Act
             var options = new CommandLineOptions();
-            var po = options.Parse(GenerateShortNameArguments(rep1: rep1, rep2: rep2, rep3: rep3).Split(' '));
+            options.Parse(GenerateShortNameArguments(rep1: rep1, rep2: rep2, rep3: rep3).Split(' '));
 
             // Assert
             Assert.True(options.Input.Count == validInputCount);

--- a/CLI.Tests/CLIOptions.cs
+++ b/CLI.Tests/CLIOptions.cs
@@ -194,7 +194,117 @@ namespace Genometric.MSPC.CLI.Tests
         {
             // Arrange & Act
             var options = new CommandLineOptions();
-            string[] arguments = "-w 1E-2 -s 1E-8 -g 1E-16 -r bio".Split(' ');
+            string[] arguments = "-w 1E-2 -s 1E-8 -r bio".Split(' ');
+
+            // Assert
+            Assert.Throws<ArgumentException>(() => options.Parse(arguments));
+        }
+
+        [Fact]
+        public void ThrowExceptionForMissingTauS()
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            string[] arguments = "-i rep1.bed -i rep2.bed -w 1E-2 -r bio".Split(' ');
+
+            // Assert
+            Assert.Throws<ArgumentException>(() => options.Parse(arguments));
+        }
+
+        [Fact]
+        public void ThrowExceptionForMissingTauW()
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            string[] arguments = "-i rep1.bed -i rep2.bed -s 1E-8 -r bio".Split(' ');
+
+            // Assert
+            Assert.Throws<ArgumentException>(() => options.Parse(arguments));
+        }
+
+        [Fact]
+        public void ThrowExceptionForMissingReplicateType()
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            string[] arguments = "-i rep1.bed -i rep2.bed -w 1E-2 -s 1E-8".Split(' ');
+
+            // Assert
+            Assert.Throws<ArgumentException>(() => options.Parse(arguments));
+        }
+
+        [Fact]
+        public void ThrowExceptionForInvalidTauW()
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            string[] arguments = "-i rep1.bed -i rep2.bed -w ABC -s 1E-8 -r bio".Split(' ');
+
+            // Assert
+            Assert.Throws<ArgumentException>(() => options.Parse(arguments));
+        }
+
+        [Fact]
+        public void ThrowExceptionForInvalidTauS()
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            string[] arguments = "-i rep1.bed -i rep2.bed -w 1E-2 -s ABC -r bio".Split(' ');
+
+            // Assert
+            Assert.Throws<ArgumentException>(() => options.Parse(arguments));
+        }
+
+        [Fact]
+        public void ThrowExceptionForInvalidReplicateType()
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            string[] arguments = "-i rep1.bed -i rep2.bed -w 1E-2 -s 1e-8 -r biooo".Split(' ');
+
+            // Assert
+            Assert.Throws<ArgumentException>(() => options.Parse(arguments));
+        }
+
+        [Fact]
+        public void ThrowExceptionForInvalidGamma()
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            string[] arguments = "-i rep1.bed -i rep2.bed -w 1E-2 -s 1e-8 -r bio -g ABC".Split(' ');
+
+            // Assert
+            Assert.Throws<ArgumentException>(() => options.Parse(arguments));
+        }
+
+        [Fact]
+        public void ThrowExceptionForInvalidAlpha()
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            string[] arguments = "-i rep1.bed -i rep2.bed -w 1E-2 -s 1e-8 -r bio -a ABC".Split(' ');
+
+            // Assert
+            Assert.Throws<ArgumentException>(() => options.Parse(arguments));
+        }
+
+        [Fact]
+        public void ThrowExceptionForInvalidC()
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            string[] arguments = "-i rep1.bed -i rep2.bed -w 1E-2 -s 1e-8 -r bio -c ABC".Split(' ');
+
+            // Assert
+            Assert.Throws<ArgumentException>(() => options.Parse(arguments));
+        }
+
+        [Fact]
+        public void ThrowExceptionForInvalidMultipleIntersection()
+        {
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            string[] arguments = "-i rep1.bed -i rep2.bed -w 1E-2 -s 1e-8 -r bio -m ABC".Split(' ');
 
             // Assert
             Assert.Throws<ArgumentException>(() => options.Parse(arguments));

--- a/CLI/CLI.csproj
+++ b/CLI/CLI.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Genometric.GeUtilities" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CLI/CommandLineOptions.cs
+++ b/CLI/CommandLineOptions.cs
@@ -6,8 +6,10 @@ using Genometric.MSPC.Model;
 using Microsoft.Extensions.CommandLineUtils;
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text;
 
+[assembly: InternalsVisibleTo("Genometric.MSPC.CLI.Tests")]
 namespace Genometric.MSPC.CLI
 {
     internal class CommandLineOptions
@@ -153,7 +155,7 @@ namespace Genometric.MSPC.CLI
             throw new ArgumentException("Invalid value given for the " + commandOption + " argument.");
         }
 
-        private Config Parse(string[] args)
+        public Config Parse(string[] args)
         {
             _cla.Execute(args);
             Options = new Config(_vreplicate, _vtauW, _vtauS, _vgamma, _vc, _valpha, _vm);

--- a/CLI/CommandLineOptions.cs
+++ b/CLI/CommandLineOptions.cs
@@ -84,6 +84,7 @@ namespace Genometric.MSPC.CLI
         private static int AssertArguments()
         {
             var missingArgs = new List<string>();
+            if (!_input.HasValue()) missingArgs.Add(_input.ShortName + "|" + _input.LongName);
             if (!_replicate.HasValue()) missingArgs.Add(_replicate.ShortName + "|" + _replicate.LongName);
             if (!_tauS.HasValue()) missingArgs.Add(_tauS.ShortName + "|" + _tauS.LongName);
             if (!_tauW.HasValue()) missingArgs.Add(_tauW.ShortName + "|" + _tauW.LongName);
@@ -96,8 +97,6 @@ namespace Genometric.MSPC.CLI
                 msgBuilder.Append(".");
                 throw new ArgumentException(msgBuilder.ToString());
             }
-
-            // TODO: check arguments value type. 
 
             return 0;
         }

--- a/CLI/CommandLineOptions.cs
+++ b/CLI/CommandLineOptions.cs
@@ -111,10 +111,31 @@ namespace Genometric.MSPC.CLI
                     break;
 
                 default:
-                    throw new ArgumentException("Invalid value given for the " + _replicate.LongName + " argument.");
+                    ThrowInvalidException(_replicate.LongName);
+                    break;
             }
 
+            if (!double.TryParse(_tauS.Value(), out _vtauS))
+                ThrowInvalidException(_tauS.LongName);
+
+            if (!double.TryParse(_tauW.Value(), out _vtauW))
+                ThrowInvalidException(_tauW.LongName);
+
+            if (!double.TryParse(_gamma.Value(), out _vgamma))
+                ThrowInvalidException(_gamma.LongName);
+
+            if (!float.TryParse(_alpha.Value(), out _valpha))
+                ThrowInvalidException(_alpha.LongName);
+
+            if (!byte.TryParse(_c.Value(), out _vc))
+                ThrowInvalidException(_c.LongName);
+
             return 0;
+        }
+
+        private void ThrowInvalidException(string commandOption)
+        {
+            throw new ArgumentException("Invalid value given for the " + commandOption + " argument.");
         }
 
         private Config Parse(string[] args)

--- a/CLI/CommandLineOptions.cs
+++ b/CLI/CommandLineOptions.cs
@@ -16,42 +16,42 @@ namespace Genometric.MSPC.CLI
     {
         private readonly CommandLineApplication _cla;
 
-        private static CommandOption _input = new CommandOption("-i | --input <value>", CommandOptionType.MultipleValue)
+        private static CommandOption _cInput = new CommandOption("-i | --input <value>", CommandOptionType.MultipleValue)
         {
             Description = "Input samples to be processed in Browser Extensible Data (BED) Format."
         };
 
-        private static CommandOption _replicate = new CommandOption("-r | --replicate <value>", CommandOptionType.SingleValue)
+        private static CommandOption _cReplicate = new CommandOption("-r | --replicate <value>", CommandOptionType.SingleValue)
         {
             Description = "Sets the replicate type of samples. Possible values are: { Bio, Biological, Tec, Technical }"
         };
 
-        private static CommandOption _tauS = new CommandOption("-s | --tauS <value>", CommandOptionType.SingleValue)
+        private static CommandOption _cTauS = new CommandOption("-s | --tauS <value>", CommandOptionType.SingleValue)
         {
             Description = "Sets stringency threshold. All peaks with p-values lower than this value are considered as stringent peaks."
         };
 
-        private static CommandOption _tauW = new CommandOption("-w | --tauW <value>", CommandOptionType.SingleValue)
+        private static CommandOption _cTauW = new CommandOption("-w | --tauW <value>", CommandOptionType.SingleValue)
         {
             Description = "Sets weak threshold. All peaks with p-values higher than this value are considered as weak peaks."
         };
 
-        private static CommandOption _gamma = new CommandOption("-g | --gamma <value>", CommandOptionType.SingleValue)
+        private static CommandOption _cGamma = new CommandOption("-g | --gamma <value>", CommandOptionType.SingleValue)
         {
             Description = "Sets combined stringency threshold. The peaks with their combined p-values satisfying this threshold will be confirmed."
         };
 
-        private static CommandOption _alpha = new CommandOption("-a | --alpha <value>", CommandOptionType.SingleValue)
+        private static CommandOption _cAlpha = new CommandOption("-a | --alpha <value>", CommandOptionType.SingleValue)
         {
             Description = "Sets false discovery rate of Benjamini–Hochberg step-up procedure."
         };
 
-        private static CommandOption _c = new CommandOption("-c <value>", CommandOptionType.SingleValue)
+        private static CommandOption _cC = new CommandOption("-c <value>", CommandOptionType.SingleValue)
         {
             Description = "Sets minimum number of overlapping peaks before combining p-values."
         };
 
-        private static CommandOption _m = new CommandOption("-m | --multipleIntersections <value>", CommandOptionType.SingleValue)
+        private static CommandOption _cM = new CommandOption("-m | --multipleIntersections <value>", CommandOptionType.SingleValue)
         {
             Description = "When multiple peaks from a sample overlap with a given peak, " +
                 "this argument defines which of the peaks to be considered: the one with lowest p-value, or " +
@@ -69,17 +69,19 @@ namespace Genometric.MSPC.CLI
 
         public Config Options { private set; get; }
 
+
+
         public CommandLineOptions()
         {
             _cla = new CommandLineApplication();
-            _cla.Options.Add(_input);
-            _cla.Options.Add(_replicate);
-            _cla.Options.Add(_tauS);
-            _cla.Options.Add(_tauW);
-            _cla.Options.Add(_gamma);
-            _cla.Options.Add(_alpha);
-            _cla.Options.Add(_c);
-            _cla.Options.Add(_m);
+            _cla.Options.Add(_cInput);
+            _cla.Options.Add(_cReplicate);
+            _cla.Options.Add(_cTauS);
+            _cla.Options.Add(_cTauW);
+            _cla.Options.Add(_cGamma);
+            _cla.Options.Add(_cAlpha);
+            _cla.Options.Add(_cC);
+            _cla.Options.Add(_cM);
             Func<int> assertArguments = AssertArguments;
             _cla.OnExecute(assertArguments);
         }
@@ -87,10 +89,10 @@ namespace Genometric.MSPC.CLI
         private int AssertArguments()
         {
             var missingArgs = new List<string>();
-            if (!_input.HasValue()) missingArgs.Add(_input.ShortName + "|" + _input.LongName);
-            if (!_replicate.HasValue()) missingArgs.Add(_replicate.ShortName + "|" + _replicate.LongName);
-            if (!_tauS.HasValue()) missingArgs.Add(_tauS.ShortName + "|" + _tauS.LongName);
-            if (!_tauW.HasValue()) missingArgs.Add(_tauW.ShortName + "|" + _tauW.LongName);
+            if (!_cInput.HasValue()) missingArgs.Add(_cInput.ShortName + "|" + _cInput.LongName);
+            if (!_cReplicate.HasValue()) missingArgs.Add(_cReplicate.ShortName + "|" + _cReplicate.LongName);
+            if (!_cTauS.HasValue()) missingArgs.Add(_cTauS.ShortName + "|" + _cTauS.LongName);
+            if (!_cTauW.HasValue()) missingArgs.Add(_cTauW.ShortName + "|" + _cTauW.LongName);
 
             if (missingArgs.Count > 0)
             {
@@ -101,7 +103,7 @@ namespace Genometric.MSPC.CLI
                 throw new ArgumentException(msgBuilder.ToString());
             }
 
-            switch (_replicate.Value().ToLower())
+            switch (_cReplicate.Value().ToLower())
             {
                 case "bio":
                 case "biological":
@@ -114,26 +116,26 @@ namespace Genometric.MSPC.CLI
                     break;
 
                 default:
-                    ThrowInvalidException(_replicate.LongName);
+                    ThrowInvalidException(_cReplicate.LongName);
                     break;
             }
 
-            if (!double.TryParse(_tauS.Value(), out _vtauS))
-                ThrowInvalidException(_tauS.LongName);
+            if (!double.TryParse(_cTauS.Value(), out _vtauS))
+                ThrowInvalidException(_cTauS.LongName);
 
-            if (!double.TryParse(_tauW.Value(), out _vtauW))
-                ThrowInvalidException(_tauW.LongName);
+            if (!double.TryParse(_cTauW.Value(), out _vtauW))
+                ThrowInvalidException(_cTauW.LongName);
 
-            if (!double.TryParse(_gamma.Value(), out _vgamma))
-                ThrowInvalidException(_gamma.LongName);
+            if (!double.TryParse(_cGamma.Value(), out _vgamma))
+                ThrowInvalidException(_cGamma.LongName);
 
-            if (!float.TryParse(_alpha.Value(), out _valpha))
-                ThrowInvalidException(_alpha.LongName);
+            if (!float.TryParse(_cAlpha.Value(), out _valpha))
+                ThrowInvalidException(_cAlpha.LongName);
 
-            if (!byte.TryParse(_c.Value(), out _vc))
-                ThrowInvalidException(_c.LongName);
+            if (!byte.TryParse(_cC.Value(), out _vc))
+                ThrowInvalidException(_cC.LongName);
 
-            switch (_m.Value().ToLower())
+            switch (_cM.Value().ToLower())
             {
                 case "lowest":
                     _vm = MultipleIntersections.UseLowestPValue;
@@ -144,7 +146,7 @@ namespace Genometric.MSPC.CLI
                     break;
 
                 default:
-                    ThrowInvalidException(_m.LongName);
+                    ThrowInvalidException(_cM.LongName);
                     break;
             }
 

--- a/CLI/CommandLineOptions.cs
+++ b/CLI/CommandLineOptions.cs
@@ -2,50 +2,105 @@
 // The Genometric organization licenses this file to you under the GNU General Public License v3.0 (GPLv3).
 // See the LICENSE file in the project root for more information.
 
-//using CommandLine;
-//using CommandLine.Text;
+using Genometric.MSPC.Model;
+using Microsoft.Extensions.CommandLineUtils;
+using System;
 using System.Collections.Generic;
 
 namespace Genometric.MSPC.CLI
 {
-    /*
     internal class CommandLineOptions
     {
-        [OptionList('i', "input", Separator = '&', Required = true, HelpText = "Input samples to be processed in Browser Extensible Data (BED) Format")]
-        public IList<string> inputFiles { set; get; }
+        private readonly CommandLineApplication _cla;
 
-        [Option('r', "replicate", Required = true, /*DefaultValue = "Biological", HelpText = "Sets the replicate type of samples. Possible values are: { Bio, Biological, Tec, Technical }")]
-        public string replicateType { set; get; }
-
-        [Option('s', "tauS", Required = true, /*DefaultValue = 1E-8, HelpText = "Sets stringency threshold. All peaks with p-values lower than this value are considered as stringent peaks")]
-        public double tauS { set; get; }
-
-        [Option('w', "tauW", Required = true, /*DefaultValue = 1E-4, HelpText = "Sets weak threshold. All peaks with p-values higher than this value are considered as weak peaks.")]
-        public double tauW { set; get; }
-
-        [Option('g', "gamma", Required = false, DefaultValue = -1, HelpText = "Sets combined stringency threshold. The peaks with their combined p-values satisfying this threshold will be confirmed.")]
-        public double gamma { set; get; }
-
-        [Option('a', "alpha", Required = false, DefaultValue = 0.05F, HelpText = "Sets false discovery rate of Benjamini–Hochberg step-up procedure")]
-        public float alpha { set; get; }
-
-        [Option('c', "C", Required = false, DefaultValue = (byte)1, HelpText = "Sets minimum number of required regions for a valid intersecting group.")]
-        public byte C { set; get; }
-
-        [Option('m', "multipleIntersections", Required = false, DefaultValue = "Lowest", HelpText = "Sets the default peak to be used when multiple peaks from one sample intesect with a given peak. Possible values are: { Lowest, Highest }")]
-        public string M { set; get; }
-
-
-        [ParserState]
-        public IParserState LastParserState { get; set; }
-
-        [HelpOption]
-        public string GetUsage()
+        private static CommandOption _input = new CommandOption("-i | --input <value>", CommandOptionType.MultipleValue)
         {
-            return HelpText.AutoBuild(this,
-              (HelpText current) => HelpText.DefaultParsingErrorsHandler(this, current));
+            Description = "Input samples to be processed in Browser Extensible Data (BED) Format."
+        };
+
+        private static CommandOption _replicate = new CommandOption("-r | --replicate <value>", CommandOptionType.SingleValue)
+        {
+            Description = "Sets the replicate type of samples. Possible values are: { Bio, Biological, Tec, Technical }"
+        };
+
+        private static CommandOption _tauS = new CommandOption("-s | --tauS <value>", CommandOptionType.SingleValue)
+        {
+            Description = "Sets stringency threshold. All peaks with p-values lower than this value are considered as stringent peaks."
+        };
+
+        private static CommandOption _tauW = new CommandOption("-w | --tauW <value>", CommandOptionType.SingleValue)
+        {
+            Description = "Sets weak threshold. All peaks with p-values higher than this value are considered as weak peaks."
+        };
+
+        private static CommandOption _gamma = new CommandOption("-g | --gamma <value>", CommandOptionType.SingleValue)
+        {
+            Description = "Sets combined stringency threshold. The peaks with their combined p-values satisfying this threshold will be confirmed."
+        };
+
+        private static CommandOption _alpha = new CommandOption("-a | --alpha <value>", CommandOptionType.SingleValue)
+        {
+            Description = "Sets false discovery rate of Benjamini–Hochberg step-up procedure."
+        };
+
+        private static CommandOption _c = new CommandOption("-c <value>", CommandOptionType.SingleValue)
+        {
+            Description = "Sets minimum number of overlapping peaks before combining p-values."
+        };
+
+        private static CommandOption _m = new CommandOption("-m | --multipleIntersections <value>", CommandOptionType.SingleValue)
+        {
+            Description = "When multiple peaks from a sample overlap with a given peak, " +
+                "this argument defines which of the peaks to be considered: the one with lowest p-value, or " +
+                "the one with highest p-value? Possible values are: { Lowest, Highest }"
+        };
+
+        private ReplicateType _vreplicate;
+        private double _vtauS = 1E-8;
+        private double _vtauW = 1E-4;
+        private double _vgamma = -1;
+        private float _valpha = 0.05F;
+        private byte _vc = 1;
+        private MultipleIntersections _vm = MultipleIntersections.UseLowestPValue;
+
+
+        public Config Options { private set; get; }
+
+        public CommandLineOptions()
+        {
+            _cla = new CommandLineApplication();
+            _cla.Options.Add(_replicate);
+            _cla.Options.Add(_tauS);
+            _cla.Options.Add(_tauW);
+            _cla.Options.Add(_gamma);
+            _cla.Options.Add(_alpha);
+            _cla.Options.Add(_c);
+            _cla.Options.Add(_m);
+            Func<int> assertArguments = AssertArguments;
+            _cla.OnExecute(assertArguments);
+        }
+
+        private static int AssertArguments()
+        {
+            var missingArgs = new List<string>();
+            if (!_replicate.HasValue()) missingArgs.Add(_replicate.ShortName + "|" + _replicate.LongName);
+            if (!_tauS.HasValue()) missingArgs.Add(_tauS.ShortName + "|" + _tauS.LongName);
+            if (!_tauW.HasValue()) missingArgs.Add(_tauW.ShortName + "|" + _tauW.LongName);
+            
+            // TODO: throw a more informative exception.
+            if (missingArgs.Count > 0)
+                throw new Exception();
+
+            // TODO: check arguments value type. 
+
+            return 0;
+        }
+
+        private Config Parse(string[] args)
+        {
+            _cla.Execute(args);
+            Options = new Config(_vreplicate, _vtauW, _vtauS, _vgamma, _vc, _valpha, _vm);
+            return Options;
         }
     }
-
-*/
 }

--- a/CLI/CommandLineOptions.cs
+++ b/CLI/CommandLineOptions.cs
@@ -111,7 +111,7 @@ namespace Genometric.MSPC.CLI
                     break;
 
                 case "tec":
-                case "Technical":
+                case "technical":
                     _vreplicate = ReplicateType.Technical;
                     break;
 

--- a/CLI/CommandLineOptions.cs
+++ b/CLI/CommandLineOptions.cs
@@ -81,7 +81,7 @@ namespace Genometric.MSPC.CLI
             _cla.OnExecute(assertArguments);
         }
 
-        private static int AssertArguments()
+        private int AssertArguments()
         {
             var missingArgs = new List<string>();
             if (!_input.HasValue()) missingArgs.Add(_input.ShortName + "|" + _input.LongName);
@@ -96,6 +96,22 @@ namespace Genometric.MSPC.CLI
                     msgBuilder.Append(item + "; ");
                 msgBuilder.Append(".");
                 throw new ArgumentException(msgBuilder.ToString());
+            }
+
+            switch (_replicate.Value().ToLower())
+            {
+                case "bio":
+                case "biological":
+                    _vreplicate = ReplicateType.Biological;
+                    break;
+
+                case "tec":
+                case "Technical":
+                    _vreplicate = ReplicateType.Technical;
+                    break;
+
+                default:
+                    throw new ArgumentException("Invalid value given for the " + _replicate.LongName + " argument.");
             }
 
             return 0;

--- a/CLI/CommandLineOptions.cs
+++ b/CLI/CommandLineOptions.cs
@@ -130,6 +130,21 @@ namespace Genometric.MSPC.CLI
             if (!byte.TryParse(_c.Value(), out _vc))
                 ThrowInvalidException(_c.LongName);
 
+            switch (_m.Value().ToLower())
+            {
+                case "lowest":
+                    _vm = MultipleIntersections.UseLowestPValue;
+                    break;
+
+                case "highest":
+                    _vm = MultipleIntersections.UseHighestPValue;
+                    break;
+
+                default:
+                    ThrowInvalidException(_m.LongName);
+                    break;
+            }
+
             return 0;
         }
 

--- a/CLI/CommandLineOptions.cs
+++ b/CLI/CommandLineOptions.cs
@@ -72,6 +72,7 @@ namespace Genometric.MSPC.CLI
         public CommandLineOptions()
         {
             _cla = new CommandLineApplication();
+            _cla.Options.Add(_input);
             _cla.Options.Add(_replicate);
             _cla.Options.Add(_tauS);
             _cla.Options.Add(_tauW);

--- a/CLI/CommandLineOptions.cs
+++ b/CLI/CommandLineOptions.cs
@@ -126,29 +126,30 @@ namespace Genometric.MSPC.CLI
             if (!double.TryParse(_cTauW.Value(), out _vtauW))
                 ThrowInvalidException(_cTauW.LongName);
 
-            if (!double.TryParse(_cGamma.Value(), out _vgamma))
+            if (_cGamma.HasValue() && !double.TryParse(_cGamma.Value(), out _vgamma))
                 ThrowInvalidException(_cGamma.LongName);
 
-            if (!float.TryParse(_cAlpha.Value(), out _valpha))
+            if (_cAlpha.HasValue() && !float.TryParse(_cAlpha.Value(), out _valpha))
                 ThrowInvalidException(_cAlpha.LongName);
 
-            if (!byte.TryParse(_cC.Value(), out _vc))
+            if (_cC.HasValue() && !byte.TryParse(_cC.Value(), out _vc))
                 ThrowInvalidException(_cC.LongName);
 
-            switch (_cM.Value().ToLower())
-            {
-                case "lowest":
-                    _vm = MultipleIntersections.UseLowestPValue;
-                    break;
+            if(_cM.HasValue())
+                switch (_cM.Value().ToLower())
+                {
+                    case "lowest":
+                        _vm = MultipleIntersections.UseLowestPValue;
+                        break;
 
-                case "highest":
-                    _vm = MultipleIntersections.UseHighestPValue;
-                    break;
+                    case "highest":
+                        _vm = MultipleIntersections.UseHighestPValue;
+                        break;
 
-                default:
-                    ThrowInvalidException(_cM.LongName);
-                    break;
-            }
+                    default:
+                        ThrowInvalidException(_cM.LongName);
+                        break;
+                }
 
             return 0;
         }

--- a/CLI/CommandLineOptions.cs
+++ b/CLI/CommandLineOptions.cs
@@ -69,7 +69,7 @@ namespace Genometric.MSPC.CLI
 
         public Config Options { private set; get; }
 
-
+        public IReadOnlyList<string> Input { get { return _cInput.Values.AsReadOnly(); } }
 
         public CommandLineOptions()
         {

--- a/CLI/CommandLineOptions.cs
+++ b/CLI/CommandLineOptions.cs
@@ -6,6 +6,7 @@ using Genometric.MSPC.Model;
 using Microsoft.Extensions.CommandLineUtils;
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace Genometric.MSPC.CLI
 {
@@ -86,10 +87,15 @@ namespace Genometric.MSPC.CLI
             if (!_replicate.HasValue()) missingArgs.Add(_replicate.ShortName + "|" + _replicate.LongName);
             if (!_tauS.HasValue()) missingArgs.Add(_tauS.ShortName + "|" + _tauS.LongName);
             if (!_tauW.HasValue()) missingArgs.Add(_tauW.ShortName + "|" + _tauW.LongName);
-            
-            // TODO: throw a more informative exception.
+
             if (missingArgs.Count > 0)
-                throw new Exception();
+            {
+                var msgBuilder = new StringBuilder("The following required arguments are missing: ");
+                foreach (var item in missingArgs)
+                    msgBuilder.Append(item + "; ");
+                msgBuilder.Append(".");
+                throw new ArgumentException(msgBuilder.ToString());
+            }
 
             // TODO: check arguments value type. 
 

--- a/CLI/CommandLineOptions.cs
+++ b/CLI/CommandLineOptions.cs
@@ -16,42 +16,42 @@ namespace Genometric.MSPC.CLI
     {
         private readonly CommandLineApplication _cla;
 
-        private static CommandOption _cInput = new CommandOption("-i | --input <value>", CommandOptionType.MultipleValue)
+        private readonly CommandOption _cInput = new CommandOption("-i | --input <value>", CommandOptionType.MultipleValue)
         {
             Description = "Input samples to be processed in Browser Extensible Data (BED) Format."
         };
 
-        private static CommandOption _cReplicate = new CommandOption("-r | --replicate <value>", CommandOptionType.SingleValue)
+        private readonly CommandOption _cReplicate = new CommandOption("-r | --replicate <value>", CommandOptionType.SingleValue)
         {
             Description = "Sets the replicate type of samples. Possible values are: { Bio, Biological, Tec, Technical }"
         };
 
-        private static CommandOption _cTauS = new CommandOption("-s | --tauS <value>", CommandOptionType.SingleValue)
+        private readonly CommandOption _cTauS = new CommandOption("-s | --tauS <value>", CommandOptionType.SingleValue)
         {
             Description = "Sets stringency threshold. All peaks with p-values lower than this value are considered as stringent peaks."
         };
 
-        private static CommandOption _cTauW = new CommandOption("-w | --tauW <value>", CommandOptionType.SingleValue)
+        private readonly CommandOption _cTauW = new CommandOption("-w | --tauW <value>", CommandOptionType.SingleValue)
         {
             Description = "Sets weak threshold. All peaks with p-values higher than this value are considered as weak peaks."
         };
 
-        private static CommandOption _cGamma = new CommandOption("-g | --gamma <value>", CommandOptionType.SingleValue)
+        private readonly CommandOption _cGamma = new CommandOption("-g | --gamma <value>", CommandOptionType.SingleValue)
         {
             Description = "Sets combined stringency threshold. The peaks with their combined p-values satisfying this threshold will be confirmed."
         };
 
-        private static CommandOption _cAlpha = new CommandOption("-a | --alpha <value>", CommandOptionType.SingleValue)
+        private readonly CommandOption _cAlpha = new CommandOption("-a | --alpha <value>", CommandOptionType.SingleValue)
         {
             Description = "Sets false discovery rate of Benjamini–Hochberg step-up procedure."
         };
 
-        private static CommandOption _cC = new CommandOption("-c <value>", CommandOptionType.SingleValue)
+        private readonly CommandOption _cC = new CommandOption("-c <value>", CommandOptionType.SingleValue)
         {
             Description = "Sets minimum number of overlapping peaks before combining p-values."
         };
 
-        private static CommandOption _cM = new CommandOption("-m | --multipleIntersections <value>", CommandOptionType.SingleValue)
+        private readonly CommandOption _cM = new CommandOption("-m | --multipleIntersections <value>", CommandOptionType.SingleValue)
         {
             Description = "When multiple peaks from a sample overlap with a given peak, " +
                 "this argument defines which of the peaks to be considered: the one with lowest p-value, or " +

--- a/MSPC.sln
+++ b/MSPC.sln
@@ -12,7 +12,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CLI", "CLI\CLI.csproj", "{C
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Core", "Core\Core.csproj", "{E1E13825-8CD9-448F-980F-A30EDAD3C497}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core.Tests", "Core.Tests\Core.Tests.csproj", "{28D3CCE8-0B9F-45B2-A050-2091DD7EA689}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Core.Tests", "Core.Tests\Core.Tests.csproj", "{28D3CCE8-0B9F-45B2-A050-2091DD7EA689}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CLI.Tests", "CLI.Tests\CLI.Tests.csproj", "{42617C98-C3DE-4970-8825-0F8E472CDB1E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -32,6 +34,10 @@ Global
 		{28D3CCE8-0B9F-45B2-A050-2091DD7EA689}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{28D3CCE8-0B9F-45B2-A050-2091DD7EA689}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{28D3CCE8-0B9F-45B2-A050-2091DD7EA689}.Release|Any CPU.Build.0 = Release|Any CPU
+		{42617C98-C3DE-4970-8825-0F8E472CDB1E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{42617C98-C3DE-4970-8825-0F8E472CDB1E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{42617C98-C3DE-4970-8825-0F8E472CDB1E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{42617C98-C3DE-4970-8825-0F8E472CDB1E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Previously the `CommandLineOptions` class (a class that defines command line arguments, their default and valid values, throws exceptions on missing values, and defines _help_) was based on a library called [CommandLine](https://github.com/commandlineparser/commandline). This library is very intuitive and simple to use; however, I have a lot of issues running it under .NET Core. Therefore, I decided to re-implement the `CommandLineOptions` class leveraging `Microsoft.Extensions.CommandLineUtils` which works as expected in .NET Core. 