### PR TITLE
Do not define a max p-value, and remove related checks

### DIFF
--- a/Core.Tests/SetsAndAttributes/Confirmed.cs
+++ b/Core.Tests/SetsAndAttributes/Confirmed.cs
@@ -156,5 +156,32 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
             // Assert
             Assert.True(res[0].Chromosomes[_chr].Get(Attributes.Confirmed).Any());
         }
+
+        [Fact]
+        public void ConfirmTwoPeaksWithVeryLowPValue()
+        {
+            // Arrange
+            var sA = new Bed<Peak>();
+            var sAP = new Peak(left: 10, right: 20, value: 5e-321);
+            sA.Add(sAP, _chr, _strand);
+
+            var sB = new Bed<Peak>();
+            var sBP = new Peak(left: 5, right: 15, value: 5e-323);
+            sB.Add(sBP, _chr, _strand);
+
+            var mspc = new MSPC<Peak>(new PeakConstructor());
+            mspc.AddSample(0, sA);
+            mspc.AddSample(1, sB);
+
+            var config = new Config(ReplicateType.Biological, 1e-4, 1e-8, 1e-8, 2, 1F, MultipleIntersections.UseLowestPValue);
+
+            // Act
+            var res = mspc.Run(config);
+
+            // Assert
+            Assert.True(
+                res[0].Chromosomes[_chr].Get(Attributes.Confirmed).Any() &&
+                res[1].Chromosomes[_chr].Get(Attributes.Confirmed).Any());
+        }
     }
 }

--- a/Core/Functions/Processor.cs
+++ b/Core/Functions/Processor.cs
@@ -268,9 +268,6 @@ namespace Genometric.MSPC.Core.Functions
 
             xsqrd = xsqrd * (-2);
 
-            if (xsqrd >= Math.Abs(Config.defaultMaxLogOfPVvalue))
-                xsqrd = Math.Abs(Config.defaultMaxLogOfPVvalue);
-
             return xsqrd;
         }
 
@@ -348,14 +345,6 @@ namespace Genometric.MSPC.Core.Functions
                                 summit: mergedPeak.Summit,
                                 value: mergingPeak.Value + mergedPeak.Value);
                         }
-
-                        if (mergingPeak.Value >= Math.Abs(Config.defaultMaxLogOfPVvalue))
-                            mergingPeak = _peakConstructor.Construct(
-                                left: mergingPeak.Left,
-                                right: mergingPeak.Right,
-                                name: mergingPeak.Name,
-                                summit: mergingPeak.Summit,
-                                value: Math.Abs(Config.defaultMaxLogOfPVvalue));
 
                         _mergedReplicates[chr.Key].Add(interval, mergingPeak);
                     }

--- a/Core/Model/Options.cs
+++ b/Core/Model/Options.cs
@@ -30,12 +30,6 @@ namespace Genometric.MSPC.Core.Model
         public MultipleIntersections MultipleIntersections { private set; get; }
 
         /// <summary>
-        /// Represents the default value for maximum log of p-value. 
-        /// p-value lower than this value will be truncated. 
-        /// </summary>
-        public const double defaultMaxLogOfPVvalue = -3000.0;
-
-        /// <summary>
         /// Represents the default value to be replace by p-value = 0
         /// of a peak when combining p-values.
         /// </summary>


### PR DESCRIPTION
If a (given or computed) p-value requires more precision than the limit of double type (`±5.0E−324` to `±1.7E308`), it (a) safely rounds a to `0`, and (b) does not break any mspc operation. 