### PR TITLE
Fix a bug with reading input samples specified via wildcard chars expanded at shell-level

### DIFF
--- a/CLI.Tests/CLIOptions.cs
+++ b/CLI.Tests/CLIOptions.cs
@@ -64,6 +64,29 @@ namespace Genometric.MSPC.CLI.Tests
         }
 
         [Fact]
+        public void ReadInputWhenWildCardCharAreExpanded()
+        {
+            /// While some shell application such as PowerShell
+            /// do not expand wildcard characters (i.e., if *.bed
+            /// is passed as an argument, the application receives
+            /// *.bed), Some other shell applications such as Mac 
+            /// Terminal expand wildcard characters (i.e., if *.bed
+            /// is passed as an argument, the application receives
+            /// a list of all files with .bed extension). This unit
+            /// test, asserts for the later.
+
+            // Arrange & Act
+            var options = new CommandLineOptions();
+            options.Parse(GenerateShortNameArguments(rep1: "rep1.bed rep2.bed rep3.bed", rep2: null, rep3: null).Split(' '));
+
+            // Assert
+            Assert.True(options.Input.Count == 3);
+            Assert.True(options.Input[0] == "rep1.bed");
+            Assert.True(options.Input[1] == "rep2.bed");
+            Assert.True(options.Input[2] == "rep3.bed");
+        }
+
+        [Fact]
         public void InputSpecifiedUsingWildCardCharacters()
         {
             // Arrange

--- a/CLI.Tests/CLIOptions.cs
+++ b/CLI.Tests/CLIOptions.cs
@@ -63,8 +63,10 @@ namespace Genometric.MSPC.CLI.Tests
                 Assert.True(options.Input[2] == rep3);
         }
 
-        [Fact]
-        public void ReadInputWhenWildCardCharAreExpanded()
+        [Theory]
+        [InlineData("rep1.bed rep2.bed rep3.bed", null, 3)]
+        [InlineData("rep1.bed rep2.bed rep3.bed", "rep4.bed rep5.bed", 5)]
+        public void ReadInputWhenWildCardCharAreExpanded(string inputArg1, string inputArg2, int inputCount)
         {
             /// While some shell application such as PowerShell
             /// do not expand wildcard characters (i.e., if *.bed
@@ -77,13 +79,18 @@ namespace Genometric.MSPC.CLI.Tests
 
             // Arrange & Act
             var options = new CommandLineOptions();
-            options.Parse(GenerateShortNameArguments(rep1: "rep1.bed rep2.bed rep3.bed", rep2: null, rep3: null).Split(' '));
+            options.Parse(GenerateShortNameArguments(rep1: inputArg1, rep2: inputArg2, rep3: null).Split(' '));
 
             // Assert
-            Assert.True(options.Input.Count == 3);
+            Assert.True(options.Input.Count == inputCount);
             Assert.True(options.Input[0] == "rep1.bed");
             Assert.True(options.Input[1] == "rep2.bed");
             Assert.True(options.Input[2] == "rep3.bed");
+            if (inputArg2 != null)
+            {
+                Assert.True(options.Input[3] == "rep4.bed");
+                Assert.True(options.Input[4] == "rep5.bed");
+            }
         }
 
         [Fact]

--- a/CLI/CommandLineOptions.cs
+++ b/CLI/CommandLineOptions.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.CommandLineUtils;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace Genometric.MSPC.CLI
@@ -196,9 +197,44 @@ namespace Genometric.MSPC.CLI
                 }
         }
 
+        private string[] ParseExpandedInput(string[] args)
+        {
+            var rtv = new List<string>();
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (args[i] == "-" + _cInput.ShortName || args[i] == "--" + _cInput.LongName)
+                {
+                    var inputs = new List<string>();
+                    for (i++; i < args.Length; i++)
+                    {
+                        if (_cla.Options.Any(x => args[i] == "-" + x.ShortName || args[i] == "--" + x.LongName))
+                        {
+                            i--;
+                            break;
+                        }
+                        else
+                            inputs.Add(args[i]);
+                    }
+
+                    foreach(var input in inputs)
+                    {
+                        rtv.Add("-" + _cInput.ShortName);
+                        rtv.Add(input);
+                    }
+                }
+                else
+                {
+                    rtv.Add(args[i]);
+                }
+            }
+
+            return rtv.ToArray();
+        }
+
         public Config Parse(string[] args)
         {
-            _cla.Execute(args);
+            var parsedInput = ParseExpandedInput(args);
+            _cla.Execute(parsedInput);
             Options = new Config(_vreplicate, _vtauW, _vtauS, _vgamma, _vc, _valpha, _vm);
             return Options;
         }


### PR DESCRIPTION
With input samples being specified via wildcard chars (e.g., `"`, or `?`), some shell programs expand the expression and some does not, before invoking MSPC with those args. This PR fixes a bug with wildcard chars expanded before passing to MSPC. 
