### PR TITLE
Extend ParserConfig

### DIFF
--- a/CLI.Tests/ParserConfig.cs
+++ b/CLI.Tests/ParserConfig.cs
@@ -11,28 +11,13 @@ namespace Genometric.MSPC.CLI.Tests
 {
     public class TParserConfig
     {
-        private bool Equal(ParserConfig obj1, ParserConfig obj2)
-        {
-            return
-                obj1.Chr == obj2.Chr &&
-                obj1.Left == obj2.Left &&
-                obj1.Right == obj2.Right &&
-                obj1.Name == obj2.Name &&
-                obj1.Strand == obj2.Strand &&
-                obj1.Summit == obj2.Summit &&
-                obj1.Value == obj2.Value &&
-                obj1.DefaultValue == obj2.DefaultValue &&
-                obj1.PValueFormat == obj2.PValueFormat &&
-                obj1.DropPeakIfInvalidValue == obj2.DropPeakIfInvalidValue;
-        }
-
         [Theory]
         [InlineData(0, 1, 2, 3, 4, 5, 6, true, 1E-4, "minus1_Log10_pValue")]
         [InlineData(5, 0, -1, 12, -1, -1, 1, false, 123.456, "SameAsInput")]
         public void ReadParserConfig(byte chr, byte left, sbyte right, byte name, sbyte strand, sbyte summit, byte value, bool dropPeakIfInvalidValue, double defaultValue, string pValueFormat)
         {
             // Arrange
-            var cols = new ParserConfig()
+            ParserConfig cols = new ParserConfig()
             {
                 Chr = chr,
                 Left = left,
@@ -51,11 +36,11 @@ namespace Genometric.MSPC.CLI.Tests
                 w.WriteLine(JsonConvert.SerializeObject(cols));
 
             // Act
-            var parsedCols = new ParserConfig().ParseBed(path);
+            ParserConfig parsedCols = new ParserConfig().ParseBed(path);
             File.Delete(path);
 
             // Assert
-            Assert.True(Equal(parsedCols, cols));
+            Assert.True(parsedCols.Equals(cols));
         }
 
         [Fact]
@@ -72,7 +57,7 @@ namespace Genometric.MSPC.CLI.Tests
             File.Delete(path);
 
             // Assert
-            Assert.True(Equal(parsedCols, expected));
+            Assert.True(parsedCols.Equals(expected));
         }
     }
 }

--- a/CLI.Tests/ParserConfig.cs
+++ b/CLI.Tests/ParserConfig.cs
@@ -2,6 +2,7 @@
 // The Genometric organization licenses this file to you under the GNU General Public License v3.0 (GPLv3).
 // See the LICENSE file in the project root for more information.
 
+using Genometric.GeUtilities.Intervals.Parsers;
 using Newtonsoft.Json;
 using System;
 using System.IO;
@@ -12,9 +13,9 @@ namespace Genometric.MSPC.CLI.Tests
     public class TParserConfig
     {
         [Theory]
-        [InlineData(0, 1, 2, 3, 4, 5, 6, true, 1E-4, "minus1_Log10_pValue")]
-        [InlineData(5, 0, -1, 12, -1, -1, 1, false, 123.456, "SameAsInput")]
-        public void ReadParserConfig(byte chr, byte left, sbyte right, byte name, sbyte strand, sbyte summit, byte value, bool dropPeakIfInvalidValue, double defaultValue, string pValueFormat)
+        [InlineData(0, 1, 2, 3, 4, 5, 6, true, 1E-4, PValueFormats.minus1_Log10_pValue)]
+        [InlineData(5, 0, -1, 12, -1, -1, 1, false, 123.456, PValueFormats.SameAsInput)]
+        public void ReadParserConfig(byte chr, byte left, sbyte right, byte name, sbyte strand, sbyte summit, byte value, bool dropPeakIfInvalidValue, double defaultValue, PValueFormats pValueFormat)
         {
             // Arrange
             ParserConfig cols = new ParserConfig()

--- a/CLI.Tests/ParserConfig.cs
+++ b/CLI.Tests/ParserConfig.cs
@@ -2,7 +2,6 @@
 // The Genometric organization licenses this file to you under the GNU General Public License v3.0 (GPLv3).
 // See the LICENSE file in the project root for more information.
 
-using Genometric.GeUtilities.Intervals.Parsers.Model;
 using Newtonsoft.Json;
 using System;
 using System.IO;

--- a/CLI.Tests/ParserConfig.cs
+++ b/CLI.Tests/ParserConfig.cs
@@ -30,7 +30,6 @@ namespace Genometric.MSPC.CLI.Tests
                 DefaultValue = defaultValue,
                 PValueFormat = pValueFormat,
                 DropPeakIfInvalidValue = dropPeakIfInvalidValue,
-
             };
             var path = Environment.CurrentDirectory + Path.DirectorySeparatorChar + "MSPCTests_" + new Random().NextDouble().ToString();
             using (StreamWriter w = new StreamWriter(path))

--- a/CLI.Tests/ParserConfig.cs
+++ b/CLI.Tests/ParserConfig.cs
@@ -36,7 +36,7 @@ namespace Genometric.MSPC.CLI.Tests
                 w.WriteLine(JsonConvert.SerializeObject(cols));
 
             // Act
-            ParserConfig parsedCols = ParserConfig.ParseBed(path);
+            ParserConfig parsedCols = ParserConfig.LoadFromJSON(path);
             File.Delete(path);
 
             // Assert
@@ -53,7 +53,7 @@ namespace Genometric.MSPC.CLI.Tests
                 w.WriteLine("{\"m\":7,\"l\":789,\"u\":-1,\"Chr\":123,\"L\":9,\"R\":2,\"d\":-1}");
 
             // Act
-            var parsedCols = ParserConfig.ParseBed(path);
+            var parsedCols = ParserConfig.LoadFromJSON(path);
             File.Delete(path);
 
             // Assert

--- a/CLI.Tests/ParserConfig.cs
+++ b/CLI.Tests/ParserConfig.cs
@@ -36,7 +36,7 @@ namespace Genometric.MSPC.CLI.Tests
                 w.WriteLine(JsonConvert.SerializeObject(cols));
 
             // Act
-            ParserConfig parsedCols = new ParserConfig().ParseBed(path);
+            ParserConfig parsedCols = ParserConfig.ParseBed(path);
             File.Delete(path);
 
             // Assert
@@ -53,7 +53,7 @@ namespace Genometric.MSPC.CLI.Tests
                 w.WriteLine("{\"m\":7,\"l\":789,\"u\":-1,\"Chr\":123,\"L\":9,\"R\":2,\"d\":-1}");
 
             // Act
-            var parsedCols = new ParserConfig().ParseBed(path);
+            var parsedCols = ParserConfig.ParseBed(path);
             File.Delete(path);
 
             // Assert

--- a/CLI.Tests/ParserConfig.cs
+++ b/CLI.Tests/ParserConfig.cs
@@ -9,9 +9,9 @@ using Xunit;
 
 namespace Genometric.MSPC.CLI.Tests
 {
-    public class ParserConfig
+    public class TParserConfig
     {
-        private bool Equal(CLI.ParserConfig obj1, CLI.ParserConfig obj2)
+        private bool Equal(ParserConfig obj1, ParserConfig obj2)
         {
             return
                 obj1.Chr == obj2.Chr &&
@@ -32,7 +32,7 @@ namespace Genometric.MSPC.CLI.Tests
         public void ReadParserConfig(byte chr, byte left, sbyte right, byte name, sbyte strand, sbyte summit, byte value, bool dropPeakIfInvalidValue, double defaultValue, string pValueFormat)
         {
             // Arrange
-            var cols = new CLI.ParserConfig()
+            var cols = new ParserConfig()
             {
                 Chr = chr,
                 Left = left,
@@ -51,7 +51,7 @@ namespace Genometric.MSPC.CLI.Tests
                 w.WriteLine(JsonConvert.SerializeObject(cols));
 
             // Act
-            var parsedCols = new CLI.ParserConfig().ParseBed(path);
+            var parsedCols = new ParserConfig().ParseBed(path);
             File.Delete(path);
 
             // Assert
@@ -62,13 +62,13 @@ namespace Genometric.MSPC.CLI.Tests
         public void ReadMalformedJSON()
         {
             // Arrange
-            var expected = new CLI.ParserConfig() { Chr = 123 };
+            var expected = new ParserConfig() { Chr = 123 };
             var path = Environment.CurrentDirectory + Path.DirectorySeparatorChar + "MSPCTests_" + new Random().NextDouble().ToString();
             using (StreamWriter w = new StreamWriter(path))
                 w.WriteLine("{\"m\":7,\"l\":789,\"u\":-1,\"Chr\":123,\"L\":9,\"R\":2,\"d\":-1}");
 
             // Act
-            var parsedCols = new CLI.ParserConfig().ParseBed(path);
+            var parsedCols = new ParserConfig().ParseBed(path);
             File.Delete(path);
 
             // Assert

--- a/CLI.Tests/ParserConfig.cs
+++ b/CLI.Tests/ParserConfig.cs
@@ -12,7 +12,7 @@ namespace Genometric.MSPC.CLI.Tests
 {
     public class ParserConfig
     {
-        private bool Equal(BedColumns obj1, BedColumns obj2)
+        private bool Equal(CLI.ParserConfig obj1, CLI.ParserConfig obj2)
         {
             return
                 obj1.Chr == obj2.Chr &&
@@ -20,23 +20,32 @@ namespace Genometric.MSPC.CLI.Tests
                 obj1.Right == obj2.Right &&
                 obj1.Name == obj2.Name &&
                 obj1.Strand == obj2.Strand &&
-                obj1.Summit == obj2.Summit;
+                obj1.Summit == obj2.Summit &&
+                obj1.Value == obj2.Value &&
+                obj1.DefaultValue == obj2.DefaultValue &&
+                obj1.PValueFormat == obj2.PValueFormat &&
+                obj1.DropPeakIfInvalidValue == obj2.DropPeakIfInvalidValue;
         }
 
         [Theory]
-        [InlineData(0, 1, 2, 3, 4, 5)]
-        [InlineData(5, 0, -1, 12, -1, -1)]
-        public void ReadParserConfig(byte chr, byte left, sbyte right, byte name, sbyte strand, sbyte summit)
+        [InlineData(0, 1, 2, 3, 4, 5, 6, true, 1E-4, "minus1_Log10_pValue")]
+        [InlineData(5, 0, -1, 12, -1, -1, 1, false, 123.456, "SameAsInput")]
+        public void ReadParserConfig(byte chr, byte left, sbyte right, byte name, sbyte strand, sbyte summit, byte value, bool dropPeakIfInvalidValue, double defaultValue, string pValueFormat)
         {
             // Arrange
-            var cols = new BedColumns()
+            var cols = new CLI.ParserConfig()
             {
                 Chr = chr,
                 Left = left,
                 Right = right,
                 Name = name,
                 Strand = strand,
-                Summit = summit
+                Summit = summit,
+                Value = value,
+                DefaultValue = defaultValue,
+                PValueFormat = pValueFormat,
+                DropPeakIfInvalidValue = dropPeakIfInvalidValue,
+
             };
             var path = Environment.CurrentDirectory + Path.DirectorySeparatorChar + "MSPCTests_" + new Random().NextDouble().ToString();
             using (StreamWriter w = new StreamWriter(path))
@@ -54,7 +63,7 @@ namespace Genometric.MSPC.CLI.Tests
         public void ReadMalformedJSON()
         {
             // Arrange
-            var expected = new BedColumns() { Chr = 123 };
+            var expected = new CLI.ParserConfig() { Chr = 123 };
             var path = Environment.CurrentDirectory + Path.DirectorySeparatorChar + "MSPCTests_" + new Random().NextDouble().ToString();
             using (StreamWriter w = new StreamWriter(path))
                 w.WriteLine("{\"m\":7,\"l\":789,\"u\":-1,\"Chr\":123,\"L\":9,\"R\":2,\"d\":-1}");

--- a/CLI/Orchestrator.cs
+++ b/CLI/Orchestrator.cs
@@ -30,9 +30,9 @@ namespace Genometric.MSPC.CLI
             _samples = new List<Bed<Peak>>();
         }
 
-        public Bed<Peak> LoadSample(string fileName, BedColumns columns)
+        public Bed<Peak> LoadSample(string fileName, ParserConfig parserConfig)
         {
-            var bedParser = new BedParser(columns)
+            var bedParser = new BedParser(parserConfig)
             {
                 PValueFormat = PValueFormats.minus1_Log10_pValue,
             };

--- a/CLI/Orchestrator.cs
+++ b/CLI/Orchestrator.cs
@@ -34,7 +34,9 @@ namespace Genometric.MSPC.CLI
         {
             var bedParser = new BedParser(parserConfig)
             {
-                PValueFormat = PValueFormats.minus1_Log10_pValue,
+                PValueFormat = parserConfig.PValueFormat,
+                DefaultValue = parserConfig.DefaultValue,
+                DropPeakIfInvalidValue = parserConfig.DropPeakIfInvalidValue
             };
             var parsedSample = bedParser.Parse(fileName);
             _samples.Add(parsedSample);

--- a/CLI/ParserConfig.cs
+++ b/CLI/ParserConfig.cs
@@ -22,7 +22,7 @@ namespace Genometric.MSPC.CLI
             PValueFormat = "minus1_Log10_pValue";
         }
 
-        public static ParserConfig ParseBed(string path)
+        public static ParserConfig LoadFromJSON(string path)
         {
             string json = null;
             using (StreamReader r = new StreamReader(path))

--- a/CLI/ParserConfig.cs
+++ b/CLI/ParserConfig.cs
@@ -4,11 +4,12 @@
 
 using Genometric.GeUtilities.Intervals.Parsers.Model;
 using Newtonsoft.Json;
+using System;
 using System.IO;
 
 namespace Genometric.MSPC.CLI
 {
-    internal class ParserConfig : BedColumns
+    internal class ParserConfig : BedColumns, IEquatable<ParserConfig>
     {
         public bool DropPeakIfInvalidValue { set; get; }
         public double DefaultValue { set; get; }
@@ -28,6 +29,22 @@ namespace Genometric.MSPC.CLI
                 json = r.ReadToEnd();
 
             return JsonConvert.DeserializeObject<ParserConfig>(json);
+        }
+
+        public bool Equals(ParserConfig other)
+        {
+            if (other == null) return false;
+            return
+                Chr == other.Chr &&
+                Left == other.Left &&
+                Right == other.Right &&
+                Name == other.Name &&
+                Summit == other.Summit &&
+                Strand == other.Strand &&
+                Value == other.Value &&
+                PValueFormat == other.PValueFormat &&
+                DefaultValue == other.DefaultValue &&
+                DropPeakIfInvalidValue == other.DropPeakIfInvalidValue;
         }
     }
 }

--- a/CLI/ParserConfig.cs
+++ b/CLI/ParserConfig.cs
@@ -22,7 +22,7 @@ namespace Genometric.MSPC.CLI
             PValueFormat = "minus1_Log10_pValue";
         }
 
-        public ParserConfig ParseBed(string path)
+        public static ParserConfig ParseBed(string path)
         {
             string json = null;
             using (StreamReader r = new StreamReader(path))

--- a/CLI/ParserConfig.cs
+++ b/CLI/ParserConfig.cs
@@ -2,6 +2,7 @@
 // The Genometric organization licenses this file to you under the GNU General Public License v3.0 (GPLv3).
 // See the LICENSE file in the project root for more information.
 
+using Genometric.GeUtilities.Intervals.Parsers;
 using Genometric.GeUtilities.Intervals.Parsers.Model;
 using Newtonsoft.Json;
 using System;
@@ -13,13 +14,13 @@ namespace Genometric.MSPC.CLI
     {
         public bool DropPeakIfInvalidValue { set; get; }
         public double DefaultValue { set; get; }
-        public string PValueFormat { set; get; }
+        public PValueFormats PValueFormat { set; get; }
 
         public ParserConfig()
         {
             DropPeakIfInvalidValue = true;
             DefaultValue = 1E-8;
-            PValueFormat = "minus1_Log10_pValue";
+            PValueFormat = PValueFormats.minus1_Log10_pValue;
         }
 
         public static ParserConfig LoadFromJSON(string path)

--- a/CLI/ParserConfig.cs
+++ b/CLI/ParserConfig.cs
@@ -8,15 +8,26 @@ using System.IO;
 
 namespace Genometric.MSPC.CLI
 {
-    internal class ParserConfig
+    internal class ParserConfig : BedColumns
     {
-        public BedColumns ParseBed(string path)
+        public bool DropPeakIfInvalidValue { set; get; }
+        public double DefaultValue { set; get; }
+        public string PValueFormat { set; get; }
+
+        public ParserConfig()
+        {
+            DropPeakIfInvalidValue = true;
+            DefaultValue = 1E-8;
+            PValueFormat = "minus1_Log10_pValue";
+        }
+
+        public ParserConfig ParseBed(string path)
         {
             string json = null;
             using (StreamReader r = new StreamReader(path))
                 json = r.ReadToEnd();
 
-            return JsonConvert.DeserializeObject<BedColumns>(json);
+            return JsonConvert.DeserializeObject<ParserConfig>(json);
         }
     }
 }

--- a/CLI/Program.cs
+++ b/CLI/Program.cs
@@ -45,9 +45,9 @@ namespace Genometric.MSPC.CLI
 
             var orchestrator = new Orchestrator(cliOptions.Options);
 
-            var bedColumns = new BedColumns();
+            var parserConfig = new BedColumns();
             if (cliOptions.ParserConfig != null)
-                bedColumns = ParserConfig.LoadFromJSON(cliOptions.ParserConfig);
+                parserConfig = ParserConfig.LoadFromJSON(cliOptions.ParserConfig);
 
             var et = new Stopwatch();
             foreach (var file in cliOptions.Input)
@@ -55,7 +55,7 @@ namespace Genometric.MSPC.CLI
                 Console.WriteLine(string.Format("Parsing sample: {0}", file));
                 et.Restart();
 
-                var parsedSample = orchestrator.LoadSample(file, bedColumns);
+                var parsedSample = orchestrator.LoadSample(file, parserConfig);
                 et.Stop();
                 Console.WriteLine("Done...  ET:\t{0}", et.Elapsed.ToString());
                 Console.WriteLine("Read peaks#:\t{0}", parsedSample.IntervalsCount.ToString("N0", CultureInfo.InvariantCulture));

--- a/CLI/Program.cs
+++ b/CLI/Program.cs
@@ -47,7 +47,7 @@ namespace Genometric.MSPC.CLI
 
             var bedColumns = new BedColumns();
             if (cliOptions.ParserConfig != null)
-                bedColumns = ParserConfig.ParseBed(cliOptions.ParserConfig);
+                bedColumns = ParserConfig.LoadFromJSON(cliOptions.ParserConfig);
 
             var et = new Stopwatch();
             foreach (var file in cliOptions.Input)

--- a/CLI/Program.cs
+++ b/CLI/Program.cs
@@ -2,7 +2,6 @@
 // The Genometric organization licenses this file to you under the GNU General Public License v3.0 (GPLv3).
 // See the LICENSE file in the project root for more information.
 
-using Genometric.GeUtilities.Intervals.Parsers.Model;
 using System;
 using System.Diagnostics;
 using System.Globalization;

--- a/CLI/Program.cs
+++ b/CLI/Program.cs
@@ -47,10 +47,7 @@ namespace Genometric.MSPC.CLI
 
             var bedColumns = new BedColumns();
             if (cliOptions.ParserConfig != null)
-            {
-                var parser = new ParserConfig();
-                bedColumns = parser.ParseBed(cliOptions.ParserConfig);
-            }
+                bedColumns = ParserConfig.ParseBed(cliOptions.ParserConfig);
 
             var et = new Stopwatch();
             foreach (var file in cliOptions.Input)

--- a/CLI/Program.cs
+++ b/CLI/Program.cs
@@ -45,7 +45,7 @@ namespace Genometric.MSPC.CLI
 
             var orchestrator = new Orchestrator(cliOptions.Options);
 
-            var parserConfig = new BedColumns();
+            var parserConfig = new ParserConfig();
             if (cliOptions.ParserConfig != null)
                 parserConfig = ParserConfig.LoadFromJSON(cliOptions.ParserConfig);
 


### PR DESCRIPTION
ParserConfig is extended with the following new keys: 

- p-value format;
- default p-value;
- drop a parsed peak if a valid p-value is not parsed for the peak