### PR TITLE
Fix a bug formatting summary statistics

### DIFF
--- a/CLI/Export/Exporter.cs
+++ b/CLI/Export/Exporter.cs
@@ -34,13 +34,8 @@ namespace Genometric.MSPC.CLI.Exporter
 
             foreach (var result in results)
             {
-                string samplePath =
-                    _options.Path +
-                    Path.DirectorySeparatorChar +
-                    Path.GetFileNameWithoutExtension(fileNames[result.Key]);
-
+                string samplePath = _options.Path + Path.DirectorySeparatorChar + fileNames[result.Key];
                 Directory.CreateDirectory(samplePath);
-
                 foreach(var attribute in options.AttributesToExport)
                     WriteToFile(samplePath, result.Value, attribute);
             }

--- a/CLI/Orchestrator.cs
+++ b/CLI/Orchestrator.cs
@@ -25,7 +25,7 @@ namespace Genometric.MSPC.CLI
         {
             get
             {
-                return _samples.ToDictionary(x => x.FileHashKey, x => x.FileName);
+                return _samples.ToDictionary(x => x.FileHashKey, x => Path.GetFileNameWithoutExtension(x.FileName));
             }
         }
 

--- a/CLI/SummaryStats.cs
+++ b/CLI/SummaryStats.cs
@@ -36,9 +36,9 @@ namespace Genometric.MSPC.CLI
             foreach (var attribute in exportedAttributes)
                 columnWidth = Math.Max(attribute.ToString().Length, columnWidth);
 
-            rtv.Add("");
+            rtv.Add(" ");
             rtv.Add(".::. Summary statistics .::.");
-            rtv.Add("");
+            rtv.Add(" ");
 
             // Create table header
             int i = 2;
@@ -76,13 +76,13 @@ namespace Genometric.MSPC.CLI
             rtv.Add(RenderRow(columnWidth, headerLines));
 
             // Consensus peaks stats
-            rtv.Add("");
+            rtv.Add(" ");
             int cPeaksCount = 0;
             foreach (var chr in consensusPeaks)
                 cPeaksCount += chr.Value.Count;
             rtv.Add(".::. Consensus Peaks Count .::.");
             rtv.Add(cPeaksCount.ToString("N0"));
-            rtv.Add("");
+            rtv.Add(" ");
 
             return rtv;
         }


### PR DESCRIPTION
Filenames for ID-filename mapping are stored with file extension, and the extension is removed when file is exported. This extension should also be removed when creating summary statistics. 

This PR implements logic to remove file extension when creating the mapping hash table. 