### PR TITLE
Update to use GeUtilities v5.3 

### DIFF
--- a/CLI/CLI.csproj
+++ b/CLI/CLI.csproj
@@ -34,9 +34,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Genometric.GeUtilities" Version="5.2.0" />
+    <PackageReference Include="Genometric.GeUtilities" Version="5.3.0" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This fixes the bug MSPC failing when a given input only contains `chr start stop`, but the parser configuration provides column number for all the attributes.