### PR TITLE
Make tracking a list of overlapping peaks an optional feature, which is disabled by default

### DIFF
--- a/Core.Tests/Basic/MultipleIntersections.cs
+++ b/Core.Tests/Basic/MultipleIntersections.cs
@@ -27,7 +27,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
         private readonly static Peak r22 = new Peak(left: 16, right: 20, name: "r22", value: 1e-6);
         private readonly static Peak r23 = new Peak(left: 26, right: 32, name: "r23", value: 1e-9);
 
-        private ReadOnlyDictionary<uint, Result<Peak>> InitializeAndRun(MultipleIntersections miChoice)
+        private ReadOnlyDictionary<uint, Result<Peak>> InitializeAndRun(MultipleIntersections miChoice, bool trackSupportingPeaks = false)
         {
             // Arrange
             var sA = new Bed<Peak>();
@@ -38,7 +38,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
             sB.Add(r22, _chr, _strand);
             sB.Add(r23, _chr, _strand);
 
-            var mspc = new Mspc();
+            var mspc = new Mspc(trackSupportingPeaks);
             mspc.AddSample(0, sA);
             mspc.AddSample(1, sB);
 
@@ -50,7 +50,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
         public void UseMostStringentPeak()
         {
             // Arrange & Act
-            var res = InitializeAndRun(MultipleIntersections.UseLowestPValue);
+            var res = InitializeAndRun(MultipleIntersections.UseLowestPValue, true);
 
             // Assert
             Assert.True(res[0].Chromosomes[_chr].Get(Attributes.Confirmed).ToList()[0].SupportingPeaks[0].Source.CompareTo(r23) == 0);
@@ -60,7 +60,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
         public void UseLeastStringentPeak()
         {
             // Arrange & Act
-            var res = InitializeAndRun(MultipleIntersections.UseHighestPValue);
+            var res = InitializeAndRun(MultipleIntersections.UseHighestPValue, true);
 
             // Assert
             Assert.True(res[0].Chromosomes[_chr].Get(Attributes.Confirmed).ToList()[0].SupportingPeaks[0].Source.CompareTo(r21) == 0);

--- a/Core/Functions/Processor.cs
+++ b/Core/Functions/Processor.cs
@@ -47,6 +47,8 @@ namespace Genometric.MSPC.Core.Functions
 
         private List<double> _cachedChiSqrd { set; get; }
 
+        private bool _trackSupportingRegions;
+
         private Config _config { set; get; }
 
         private Dictionary<uint, Bed<I>> _samples { set; get; }
@@ -55,10 +57,11 @@ namespace Genometric.MSPC.Core.Functions
 
         internal int SamplesCount { get { return _samples.Count; } }
 
-        internal Processor(IPeakConstructor<I> peakConstructor)
+        internal Processor(IPeakConstructor<I> peakConstructor, bool trackSupportingRegions)
         {
             _samples = new Dictionary<uint, Bed<I>>();
             _peakConstructor = peakConstructor;
+            _trackSupportingRegions = trackSupportingRegions;
             DegreeOfParallelism = Environment.ProcessorCount;
         }
 
@@ -165,7 +168,7 @@ namespace Genometric.MSPC.Core.Functions
                         attribute = Attributes.Weak;
                     else
                     {
-                        var pp = new ProcessedPeak<I>(peak, double.NaN, new List<SupportingPeak<I>>());
+                        var pp = new ProcessedPeak<I>(peak, double.NaN);
                         pp.Classification.Add(Attributes.Background);
                         _analysisResults[sampleKey].Chromosomes[chr.Key].AddOrUpdate(pp);
                         continue;

--- a/Core/Functions/Processor.cs
+++ b/Core/Functions/Processor.cs
@@ -178,7 +178,11 @@ namespace Genometric.MSPC.Core.Functions
                     if (supportingPeaks.Count + 1 >= _config.C)
                     {
                         double xsqrd = CalculateXsqrd(peak, supportingPeaks);
-                        var pp = new ProcessedPeak<I>(peak, xsqrd, supportingPeaks);
+                        ProcessedPeak<I> pp;
+                        if (_trackSupportingRegions)
+                            pp = new ProcessedPeak<I>(peak, xsqrd, supportingPeaks);
+                        else
+                            pp = new ProcessedPeak<I>(peak, xsqrd, supportingPeaks.Count);
                         pp.Classification.Add(attribute);
                         if (xsqrd >= _cachedChiSqrd[supportingPeaks.Count])
                         {
@@ -236,9 +240,9 @@ namespace Genometric.MSPC.Core.Functions
                     default:
                         var chosenPeak = sps[0];
                         foreach (var sp in sps.Skip(1))
-                            if ((_config.MultipleIntersections == MultipleIntersections.UseLowestPValue 
+                            if ((_config.MultipleIntersections == MultipleIntersections.UseLowestPValue
                                 && sp.Value < chosenPeak.Value) ||
-                                (_config.MultipleIntersections == MultipleIntersections.UseHighestPValue 
+                                (_config.MultipleIntersections == MultipleIntersections.UseHighestPValue
                                 && sp.Value > chosenPeak.Value))
                                 chosenPeak = sp;
 

--- a/Core/Functions/Processor.cs
+++ b/Core/Functions/Processor.cs
@@ -204,7 +204,7 @@ namespace Genometric.MSPC.Core.Functions
                     }
                     else
                     {
-                        var pp = new ProcessedPeak<I>(peak, 0, supportingPeaks);
+                        var pp = new ProcessedPeak<I>(peak, 0, supportingPeaks.Count);
                         pp.Classification.Add(attribute);
                         pp.Classification.Add(Attributes.Discarded);
                         pp.reason = Messages.Codes.M002;
@@ -268,7 +268,12 @@ namespace Genometric.MSPC.Core.Functions
                     if (supPeak.CompareTo(sP) != 0)
                         tSupPeak.Add(sP);
 
-                var pp = new ProcessedPeak<I>(supPeak.Source, xsqrd, tSupPeak);
+                ProcessedPeak<I> pp;
+                if (_trackSupportingRegions)
+                    pp = new ProcessedPeak<I>(supPeak.Source, xsqrd, tSupPeak);
+                else
+                    pp = new ProcessedPeak<I>(supPeak.Source, xsqrd, tSupPeak.Count);
+
                 pp.Classification.Add(attribute);
                 pp.reason = message;
 

--- a/Core/Model/ProcessedPeak.cs
+++ b/Core/Model/ProcessedPeak.cs
@@ -81,7 +81,6 @@ namespace Genometric.MSPC.Core.Model
                    EqualityComparer<I>.Default.Equals(Source, peak.Source) &&
                    ((double.IsNaN(XSquared) && double.IsNaN(peak.XSquared)) || XSquared == peak.XSquared) &&
                    ((double.IsNaN(RTP) && double.IsNaN(peak.RTP)) || RTP == peak.RTP) &&
-                   !SupportingPeaks.Except(peak.SupportingPeaks).Any() &&
                    Reason == peak.Reason &&
                    !Classification.Except(peak.Classification).Any() &&
                    ((double.IsNaN(AdjPValue) && double.IsNaN(peak.AdjPValue)) || AdjPValue == peak.AdjPValue);
@@ -89,7 +88,7 @@ namespace Genometric.MSPC.Core.Model
 
         public override int GetHashCode()
         {
-            string key = base.GetHashCode() + "_" + XSquared + "_" + RTP + "_" + SupportingPeaks.Count;
+            string key = base.GetHashCode() + "_" + XSquared + "_" + RTP;
             int l = key.Length;
 
             int hashKey = 0;

--- a/Core/Model/ProcessedPeak.cs
+++ b/Core/Model/ProcessedPeak.cs
@@ -35,7 +35,6 @@ namespace Genometric.MSPC.Core.Model
             else
                 RTP = ChiSqrd.ChiSqrdDistRTP(XSquared, 2 + (supportingPeaksCount * 2));
             Classification = new HashSet<Attributes>();
-            SupportingPeaks = new List<SupportingPeak<I>>().AsReadOnly();
         }
             
 

--- a/Core/Model/ProcessedPeak.cs
+++ b/Core/Model/ProcessedPeak.cs
@@ -25,7 +25,7 @@ namespace Genometric.MSPC.Core.Model
             SupportingPeaks = supportingPeaks;
         }
 
-        public ProcessedPeak(I source, double xSquared, int supportingPeaksCount):
+        public ProcessedPeak(I source, double xSquared, int supportingPeaksCount = 0) :
             base(source)
         {
             AdjPValue = double.NaN;

--- a/Core/Mspc.cs
+++ b/Core/Mspc.cs
@@ -8,7 +8,7 @@ namespace Genometric.MSPC.Core
 {
     public class Mspc : Mspc<Peak>
     {
-        public Mspc() : base(new PeakConstructor())
+        public Mspc(bool trackSupportingRegions = false) : base(new PeakConstructor(), trackSupportingRegions)
         { }
     }
 }

--- a/Core/MspcGeneric.cs
+++ b/Core/MspcGeneric.cs
@@ -37,9 +37,9 @@ namespace Genometric.MSPC.Core
             get { return _processor.DegreeOfParallelism; }
         }
 
-        public Mspc(IPeakConstructor<I> peakConstructor)
+        public Mspc(IPeakConstructor<I> peakConstructor, bool trackSupportingRegions = false)
         {
-            _processor = new Processor<I>(peakConstructor);
+            _processor = new Processor<I>(peakConstructor, trackSupportingRegions);
             _processor.OnProgressUpdate += _processorOnProgressUpdate;
             _backgroundProcessor = new BackgroundWorker();
             _backgroundProcessor.DoWork += _doWork;


### PR DESCRIPTION
built based on https://github.com/Genometric/MSPC/pull/72