### PR TITLE
Memory optimization by improving how attributes are stored for a processed peak.

### DIFF
--- a/Core.Tests/Basic/TConsensusPeaks.cs
+++ b/Core.Tests/Basic/TConsensusPeaks.cs
@@ -142,10 +142,10 @@ namespace Genometric.MSPC.Core.Tests.Basic
             var r4 = cPeaks[_chrs[4]].First(x => x.Source.Left == 70);
 
             // Assert
-            Assert.Contains(Attributes.TruePositive, r1.Classification);
-            Assert.Contains(Attributes.TruePositive, r2.Classification);
-            Assert.Contains(Attributes.TruePositive, r3.Classification);
-            Assert.Contains(Attributes.FalsePositive, r4.Classification);
+            Assert.True(r1.HasAttribute(Attributes.TruePositive));
+            Assert.True(r2.HasAttribute(Attributes.TruePositive));
+            Assert.True(r3.HasAttribute(Attributes.TruePositive));
+            Assert.True(r4.HasAttribute(Attributes.FalsePositive));
         }
     }
 }

--- a/Core.Tests/Example/Eg1.cs
+++ b/Core.Tests/Example/Eg1.cs
@@ -99,8 +99,8 @@ namespace Genometric.MSPC.Core.Tests.Example
 
             // Assert
             Assert.NotNull(qres);
-            Assert.Contains(initial, qres.Classification);
-            Assert.Contains(processed, qres.Classification);
+            Assert.True(qres.HasAttribute(initial));
+            Assert.True(qres.HasAttribute(processed));
         }
 
         [Theory]

--- a/Core.Tests/Replicates/BioAttributes.cs
+++ b/Core.Tests/Replicates/BioAttributes.cs
@@ -20,11 +20,11 @@ namespace Genometric.MSPC.Core.Tests.Replicates
 
             var confirmedPeak = new ProcessedPeak<Peak>(
                 new Peak(1, 10, 100), 10, new List<SupportingPeak<Peak>>());
-            confirmedPeak.Classification.Add(Attributes.Confirmed);
+            confirmedPeak.AddClassification(Attributes.Confirmed);
 
             var discardedPeak = new ProcessedPeak<Peak>(
                 new Peak(1, 10, 100), 10, new List<SupportingPeak<Peak>>());
-            discardedPeak.Classification.Add(Attributes.Discarded);
+            discardedPeak.AddClassification(Attributes.Discarded);
 
             // Act
             sets.AddOrUpdate(discardedPeak);

--- a/Core/Functions/FalseDiscoveryRate.cs
+++ b/Core/Functions/FalseDiscoveryRate.cs
@@ -58,9 +58,9 @@ namespace Genometric.MSPC.Core.Functions
             for (int i = 0; i < m; i++)
             {
                 if (peaks[i].Source.Value <= (i + 1) / (double)m * alpha)
-                    peaks[i].Classification.Add(Attributes.TruePositive);
+                    peaks[i].AddClassification(Attributes.TruePositive);
                 else
-                    peaks[i].Classification.Add(Attributes.FalsePositive);
+                    peaks[i].AddClassification(Attributes.FalsePositive);
 
                 // False discovery rate based on Benjamini and Hochberg Multiple Testing Correction.
                 peaks[i].AdjPValue = peaks[i].Source.Value * (m / (i + 1.0));

--- a/Core/Functions/Processor.cs
+++ b/Core/Functions/Processor.cs
@@ -169,7 +169,7 @@ namespace Genometric.MSPC.Core.Functions
                     else
                     {
                         var pp = new ProcessedPeak<I>(peak, double.NaN);
-                        pp.Classification.Add(Attributes.Background);
+                        pp.AddClassification(Attributes.Background);
                         _analysisResults[sampleKey].Chromosomes[chr.Key].AddOrUpdate(pp);
                         continue;
                     }
@@ -183,10 +183,10 @@ namespace Genometric.MSPC.Core.Functions
                             pp = new ProcessedPeak<I>(peak, xsqrd, supportingPeaks);
                         else
                             pp = new ProcessedPeak<I>(peak, xsqrd, supportingPeaks.Count);
-                        pp.Classification.Add(attribute);
+                        pp.AddClassification(attribute);
                         if (xsqrd >= _cachedChiSqrd[supportingPeaks.Count])
                         {
-                            pp.Classification.Add(Attributes.Confirmed);
+                            pp.AddClassification(Attributes.Confirmed);
                             _analysisResults[sampleKey].Chromosomes[chr.Key].AddOrUpdate(pp);
                             ProcessSupportingPeaks(
                                 sampleKey, chr.Key, peak, supportingPeaks,
@@ -195,7 +195,7 @@ namespace Genometric.MSPC.Core.Functions
                         else
                         {
                             pp.reason = Messages.Codes.M001;
-                            pp.Classification.Add(Attributes.Discarded);
+                            pp.AddClassification(Attributes.Discarded);
                             _analysisResults[sampleKey].Chromosomes[chr.Key].AddOrUpdate(pp);
                             ProcessSupportingPeaks(
                                 sampleKey, chr.Key, peak, supportingPeaks,
@@ -205,8 +205,8 @@ namespace Genometric.MSPC.Core.Functions
                     else
                     {
                         var pp = new ProcessedPeak<I>(peak, 0, supportingPeaks.Count);
-                        pp.Classification.Add(attribute);
-                        pp.Classification.Add(Attributes.Discarded);
+                        pp.AddClassification(attribute);
+                        pp.AddClassification(Attributes.Discarded);
                         pp.reason = Messages.Codes.M002;
                         _analysisResults[sampleKey].Chromosomes[chr.Key].AddOrUpdate(pp);
                     }
@@ -274,13 +274,13 @@ namespace Genometric.MSPC.Core.Functions
                 else
                     pp = new ProcessedPeak<I>(supPeak.Source, xsqrd, tSupPeak.Count);
 
-                pp.Classification.Add(attribute);
+                pp.AddClassification(attribute);
                 pp.reason = message;
 
                 if (supPeak.Source.Value <= _config.TauS)
-                    pp.Classification.Add(Attributes.Stringent);
+                    pp.AddClassification(Attributes.Stringent);
                 else
-                    pp.Classification.Add(Attributes.Weak);
+                    pp.AddClassification(Attributes.Weak);
 
                 _analysisResults[supPeak.SampleID].Chromosomes[chr].AddOrUpdate(pp);
             }

--- a/Core/Model/Enums.cs
+++ b/Core/Model/Enums.cs
@@ -6,13 +6,13 @@ namespace Genometric.MSPC.Core.Model
 {
     public enum Attributes : byte
     {
-        Background = 0,
-        Weak = 1,
-        Stringent = 2,
-        Confirmed = 3,
-        Discarded = 4,
-        TruePositive = 5,
-        FalsePositive = 6
+        Background = 2,
+        Weak = 4,
+        Stringent = 8,
+        Confirmed = 16,
+        Discarded = 32,
+        TruePositive = 64,
+        FalsePositive = 128
     };
 
     public enum MultipleIntersections : byte

--- a/Core/Model/ProcessedPeak.cs
+++ b/Core/Model/ProcessedPeak.cs
@@ -34,7 +34,6 @@ namespace Genometric.MSPC.Core.Model
                 RTP = double.NaN;
             else
                 RTP = ChiSqrd.ChiSqrdDistRTP(XSquared, 2 + (supportingPeaksCount * 2));
-            Classification = new HashSet<Attributes>();
         }
             
 
@@ -57,10 +56,28 @@ namespace Genometric.MSPC.Core.Model
         public string Reason { get { return Decode(reason); } }
         internal Codes reason = Codes.M000;
 
-        /// <summary>
-        /// Sets and gets classification type. 
-        /// </summary>
-        public HashSet<Attributes> Classification { internal set; get; }
+        private byte _classification;
+
+        public void AddClassification(Attributes attribute)
+        {
+            if (!HasAttribute(attribute))
+                _classification += (byte)attribute;
+        }
+
+        public bool HasAttribute(Attributes attribute)
+        {
+            return (_classification & (byte)attribute) == (byte)attribute;
+        }
+
+        public bool Different(Attributes attribute)
+        {
+            return _classification != (byte)attribute;
+        }
+
+        public bool Different(byte attribute)
+        {
+            return _classification != attribute;
+        }
 
         /// <summary>
         /// Sets and gets adjusted p-value (false discovery rate) using the 
@@ -82,7 +99,7 @@ namespace Genometric.MSPC.Core.Model
                    ((double.IsNaN(XSquared) && double.IsNaN(peak.XSquared)) || XSquared == peak.XSquared) &&
                    ((double.IsNaN(RTP) && double.IsNaN(peak.RTP)) || RTP == peak.RTP) &&
                    Reason == peak.Reason &&
-                   !Classification.Except(peak.Classification).Any() &&
+                   !peak.Different(_classification) &&
                    ((double.IsNaN(AdjPValue) && double.IsNaN(peak.AdjPValue)) || AdjPValue == peak.AdjPValue);
         }
 

--- a/Core/Model/Sets.cs
+++ b/Core/Model/Sets.cs
@@ -26,14 +26,14 @@ namespace Genometric.MSPC.Core.Model
             {
                 if (_replicateType == ReplicateType.Biological)
                 {
-                    if ((oldValue.Classification.Contains(Attributes.Discarded) && processedPeak.Classification.Contains(Attributes.Confirmed)) ||
-                        (!oldValue.Classification.Contains(Attributes.Confirmed) && !oldValue.Classification.Contains(Attributes.Discarded)))
+                    if ((oldValue.HasAttribute(Attributes.Discarded) && processedPeak.HasAttribute(Attributes.Confirmed)) ||
+                        (!oldValue.HasAttribute(Attributes.Confirmed) && !oldValue.HasAttribute(Attributes.Discarded)))
                         _peaks[processedPeak.Source.GetHashCode()] = processedPeak;
                 }
                 else
                 {
-                    if (oldValue.Classification.Contains(Attributes.Confirmed) && processedPeak.Classification.Contains(Attributes.Discarded) ||
-                        (!oldValue.Classification.Contains(Attributes.Confirmed) && !oldValue.Classification.Contains(Attributes.Discarded)))
+                    if (oldValue.HasAttribute(Attributes.Confirmed) && processedPeak.HasAttribute(Attributes.Discarded) ||
+                        (!oldValue.HasAttribute(Attributes.Confirmed) && !oldValue.HasAttribute(Attributes.Discarded)))
                         _peaks[processedPeak.Source.GetHashCode()] = processedPeak;
                 }
             }
@@ -45,12 +45,12 @@ namespace Genometric.MSPC.Core.Model
 
         public IEnumerable<ProcessedPeak<I>> Get(Attributes attributes)
         {
-            return _peaks.Where(kvp => kvp.Value.Classification.Contains(attributes)).Select(kvp => kvp.Value);
+            return _peaks.Where(kvp => kvp.Value.HasAttribute(attributes)).Select(kvp => kvp.Value);
         }
 
         public int Count(Attributes attribute)
         {
-            return _peaks.Count(kvp => kvp.Value.Classification.Contains(attribute));
+            return _peaks.Count(kvp => kvp.Value.HasAttribute(attribute));
         }
     }
 }


### PR DESCRIPTION
Attributes of a processed peak (e.g., Weak, Stringent, Confirmed, Discarded, True-Positive) were stored in a hashset, which was consuming significant amount of memory. See the following heap snapshot:

<img width="864" alt="before optimization" src="https://user-images.githubusercontent.com/9027482/51400362-13a2df80-1afd-11e9-930d-060d2c5bce83.png">

This PR replaces the hashset with a single object of type `byte`, and tracks attributes using bit-wise operations on the `byte` object. For instance:

`0000 0010`: Background
`0001 0000`: Confirmed
`0001 1000`: Stringent and Confirmed
`1001 1000`: False-Positive, Stringent, and Confirmed

Hence to check if a peak is confirmed, we can `AND` the `Confirmed` attribute with this `byte` and if the result equals `Confirmed` then we reason that the peak is confirmed. For instance: 

`1001 1000 & 0000 1000 -> 0000 1000`  

(see changes to `Attributes` enum, and the new method on how they handle these operations). 

This change results in `73%` improvement when processing `1,518,033` peaks; see the following heap snapshots: 

|      | Objects (Diff)  |  Heap Size (Diff) |
| -- | --------------- | ------------------ |
| Before | 18,423,765 | 994,774.77 KB |
| After   |  13,871,612 | 733,999.63 KB |