### PR TITLE
Collapse multiple interval trees into a single tree. 

### DIFF
--- a/Core/Functions/Processor.cs
+++ b/Core/Functions/Processor.cs
@@ -122,7 +122,7 @@ namespace Genometric.MSPC.Core.Functions
                         foreach (I p in strand.Value.Intervals)
                             if (p.Value < _config.TauW)
                             {
-                                _trees[sample.Key][chr.Key].Add(p);
+                                _trees[sample.Key][chr.Key].Add(p, sample.Key);
                                 _peaksToBeProcessed++;
                             }
                 }
@@ -225,7 +225,7 @@ namespace Genometric.MSPC.Core.Functions
                 if (tree.Key == id)
                     continue;
 
-                var sps = new List<I>();
+                var sps = new List<NodeData<I>>();
                 if (_trees[tree.Key].ContainsKey(chr))
                     sps = _trees[tree.Key][chr].GetIntervals(p);
 
@@ -234,19 +234,19 @@ namespace Genometric.MSPC.Core.Functions
                     case 0: break;
 
                     case 1:
-                        supportingPeaks.Add(new SupportingPeak<I>(sps[0], tree.Key));
+                        supportingPeaks.Add(new SupportingPeak<I>(sps[0].Peak, tree.Key));
                         break;
 
                     default:
                         var chosenPeak = sps[0];
                         foreach (var sp in sps.Skip(1))
                             if ((_config.MultipleIntersections == MultipleIntersections.UseLowestPValue
-                                && sp.Value < chosenPeak.Value) ||
+                                && sp.Peak.Value < chosenPeak.Peak.Value) ||
                                 (_config.MultipleIntersections == MultipleIntersections.UseHighestPValue
-                                && sp.Value > chosenPeak.Value))
+                                && sp.Peak.Value > chosenPeak.Peak.Value))
                                 chosenPeak = sp;
 
-                        supportingPeaks.Add(new SupportingPeak<I>(chosenPeak, tree.Key));
+                        supportingPeaks.Add(new SupportingPeak<I>(chosenPeak.Peak, tree.Key));
                         break;
                 }
             }

--- a/Core/Functions/Processor.cs
+++ b/Core/Functions/Processor.cs
@@ -42,8 +42,6 @@ namespace Genometric.MSPC.Core.Functions
             get { return new ReadOnlyDictionary<string, List<ProcessedPeak<I>>>(_consensusPeaks); }
         }
 
-        private Dictionary<uint, SupportingPeak<I>> _supPeakFilterHelper;
-
         public int DegreeOfParallelism { set; get; }
 
         private List<double> _cachedChiSqrd { set; get; }
@@ -111,7 +109,6 @@ namespace Genometric.MSPC.Core.Functions
         {
             _tree = new Dictionary<string, Tree<I>>();
             _analysisResults = new Dictionary<uint, Result<I>>();
-            _supPeakFilterHelper = new Dictionary<uint, SupportingPeak<I>>(capacity: _samples.Count);
             foreach (var sample in _samples)
             {
                 _analysisResults.Add(sample.Key, new Result<I>(_config.ReplicateType));
@@ -237,7 +234,7 @@ namespace Genometric.MSPC.Core.Functions
                     break;
 
                 default:
-                    _supPeakFilterHelper.Clear();
+                    var _supPeakFilterHelper = new Dictionary<uint, SupportingPeak<I>>(overlappingPeaks.Count);
                     foreach (var p in overlappingPeaks)
                     {
                         if (_supPeakFilterHelper.TryGetValue(p.SampleID, out SupportingPeak<I> chosenPeak))

--- a/Core/IntervalTree/Node.cs
+++ b/Core/IntervalTree/Node.cs
@@ -62,7 +62,7 @@ namespace Genometric.MSPC.Core.IntervalTree
                 _rightNode = new Node<I, D>(right);
         }
 
-        public List<NodeData<I>> Query(D target)
+        public List<NodeData<I>> Query(D target, uint skipID)
         {
             var result = new List<NodeData<I>>();
 
@@ -70,14 +70,17 @@ namespace Genometric.MSPC.Core.IntervalTree
                 if (target.Peak.Right.CompareTo(entry.Key.Peak.Left) > 0 &&
                     target.Peak.Left.CompareTo(entry.Key.Peak.Right) < 0)
                     foreach (var interval in entry.Value)
-                        result.Add(interval);
-                else if (entry.Key.Peak.Left.CompareTo(target.Peak.Right) > 0)
-                    break;
+                    {
+                        if (interval.SampleID != skipID)
+                            result.Add(interval);
+                    }
+                /// else if (entry.Key.Peak.Left.CompareTo(target.Peak.Right) > 0)
+                ///     break;
 
             if (target.Peak.Left.CompareTo(_center) < 0 && _leftNode != null)
-                result.AddRange(_leftNode.Query(target));
+                result.AddRange(_leftNode.Query(target, skipID));
             if (target.Peak.Right.CompareTo(_center) > 0 && _rightNode != null)
-                result.AddRange(_rightNode.Query(target));
+                result.AddRange(_rightNode.Query(target, skipID));
             return result;
         }
     }

--- a/Core/IntervalTree/Node.cs
+++ b/Core/IntervalTree/Node.cs
@@ -8,47 +8,48 @@ using System.Linq;
 
 namespace Genometric.MSPC.Core.IntervalTree
 {
-    internal class Node<I>
+    internal class Node<I, D>
         where I : IPeak
+        where D : NodeData<I>
     {
-        private readonly SortedDictionary<I, List<I>> _intervals;
+        private readonly SortedDictionary<D, List<D>> _intervals;
         private readonly int _center;
-        private readonly Node<I> _leftNode;
-        private readonly Node<I> _rightNode;
+        private readonly Node<I, D> _leftNode;
+        private readonly Node<I, D> _rightNode;
 
         public Node()
         {
-            _intervals = new SortedDictionary<I, List<I>>();
+            _intervals = new SortedDictionary<D, List<D>>();
             _center = 0;
             _leftNode = null;
             _rightNode = null;
         }
 
-        public Node(List<I> intervalsList)
+        public Node(List<D> intervalsList)
         {
-            _intervals = new SortedDictionary<I, List<I>>();
+            _intervals = new SortedDictionary<D, List<D>>();
             var endpoints = new SortedSet<int>();
             foreach (var interval in intervalsList)
             {
-                endpoints.Add(interval.Left);
-                endpoints.Add(interval.Right);
+                endpoints.Add(interval.Peak.Left);
+                endpoints.Add(interval.Peak.Right);
             }
             _center = endpoints.ElementAt(endpoints.Count / 2);
 
-            var left = new List<I>();
-            var right = new List<I>();
+            var left = new List<D>();
+            var right = new List<D>();
 
-            foreach (I interval in intervalsList)
+            foreach (D interval in intervalsList)
             {
-                if (interval.Right.CompareTo(_center) < 0)
+                if (interval.Peak.Right.CompareTo(_center) < 0)
                     left.Add(interval);
-                else if (interval.Left.CompareTo(_center) > 0)
+                else if (interval.Peak.Left.CompareTo(_center) > 0)
                     right.Add(interval);
                 else
                 {
-                    if (!_intervals.TryGetValue(interval, out List<I> posting))
+                    if (!_intervals.TryGetValue(interval, out List<D> posting))
                     {
-                        posting = new List<I>();
+                        posting = new List<D>();
                         _intervals.Add(interval, posting);
                     }
                     posting.Add(interval);
@@ -56,26 +57,26 @@ namespace Genometric.MSPC.Core.IntervalTree
             }
 
             if (left.Count > 0)
-                _leftNode = new Node<I>(left);
+                _leftNode = new Node<I, D>(left);
             if (right.Count > 0)
-                _rightNode = new Node<I>(right);
+                _rightNode = new Node<I, D>(right);
         }
 
-        public List<I> Query(I target)
+        public List<NodeData<I>> Query(D target)
         {
-            List<I> result = new List<I>();
+            var result = new List<NodeData<I>>();
 
             foreach (var entry in _intervals)
-                if (target.Right.CompareTo(entry.Key.Left) > 0 &&
-                    target.Left.CompareTo(entry.Key.Right) < 0)
-                    foreach (I interval in entry.Value)
+                if (target.Peak.Right.CompareTo(entry.Key.Peak.Left) > 0 &&
+                    target.Peak.Left.CompareTo(entry.Key.Peak.Right) < 0)
+                    foreach (var interval in entry.Value)
                         result.Add(interval);
-                else if (entry.Key.Left.CompareTo(target.Right) > 0)
+                else if (entry.Key.Peak.Left.CompareTo(target.Peak.Right) > 0)
                     break;
 
-            if (target.Left.CompareTo(_center) < 0 && _leftNode != null)
+            if (target.Peak.Left.CompareTo(_center) < 0 && _leftNode != null)
                 result.AddRange(_leftNode.Query(target));
-            if (target.Right.CompareTo(_center) > 0 && _rightNode != null)
+            if (target.Peak.Right.CompareTo(_center) > 0 && _rightNode != null)
                 result.AddRange(_rightNode.Query(target));
             return result;
         }

--- a/Core/IntervalTree/Node.cs
+++ b/Core/IntervalTree/Node.cs
@@ -74,8 +74,8 @@ namespace Genometric.MSPC.Core.IntervalTree
                         if (interval.SampleID != skipID)
                             result.Add(interval);
                     }
-                /// else if (entry.Key.Peak.Left.CompareTo(target.Peak.Right) > 0)
-                ///     break;
+                else if (entry.Key.Peak.Left.CompareTo(target.Peak.Right) > 0)
+                    break;
 
             if (target.Peak.Left.CompareTo(_center) < 0 && _leftNode != null)
                 result.AddRange(_leftNode.Query(target, skipID));

--- a/Core/IntervalTree/Node.cs
+++ b/Core/IntervalTree/Node.cs
@@ -12,14 +12,14 @@ namespace Genometric.MSPC.Core.IntervalTree
         where I : IPeak
         where D : NodeData<I>
     {
-        private readonly SortedDictionary<D, List<D>> _intervals;
+        private readonly SortedDictionary<D, uint> _intervals;
         private readonly int _center;
         private readonly Node<I, D> _leftNode;
         private readonly Node<I, D> _rightNode;
 
         public Node()
         {
-            _intervals = new SortedDictionary<D, List<D>>();
+            _intervals = new SortedDictionary<D, uint>();
             _center = 0;
             _leftNode = null;
             _rightNode = null;
@@ -27,7 +27,7 @@ namespace Genometric.MSPC.Core.IntervalTree
 
         public Node(List<D> intervalsList)
         {
-            _intervals = new SortedDictionary<D, List<D>>();
+            _intervals = new SortedDictionary<D, uint>();
             var endpoints = new SortedSet<int>();
             foreach (var interval in intervalsList)
             {
@@ -47,12 +47,7 @@ namespace Genometric.MSPC.Core.IntervalTree
                     right.Add(interval);
                 else
                 {
-                    if (!_intervals.TryGetValue(interval, out List<D> posting))
-                    {
-                        posting = new List<D>();
-                        _intervals.Add(interval, posting);
-                    }
-                    posting.Add(interval);
+                    _intervals.Add(interval, interval.SampleID);
                 }
             }
 
@@ -69,11 +64,10 @@ namespace Genometric.MSPC.Core.IntervalTree
             foreach (var entry in _intervals)
                 if (target.Peak.Right.CompareTo(entry.Key.Peak.Left) > 0 &&
                     target.Peak.Left.CompareTo(entry.Key.Peak.Right) < 0)
-                    foreach (var interval in entry.Value)
-                    {
-                        if (interval.SampleID != skipID)
-                            result.Add(interval);
-                    }
+                {
+                    if (entry.Value != skipID)
+                        result.Add(entry.Key);
+                }
                 else if (entry.Key.Peak.Left.CompareTo(target.Peak.Right) > 0)
                     break;
 

--- a/Core/IntervalTree/NodeData.cs
+++ b/Core/IntervalTree/NodeData.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the Genometric organization (https://github.com/Genometric) under one or more agreements.
+// The Genometric organization licenses this file to you under the GNU General Public License v3.0 (GPLv3).
+// See the LICENSE file in the project root for more information.
+
+using Genometric.GeUtilities.IGenomics;
+
+namespace Genometric.MSPC.Core.IntervalTree
+{
+    internal class NodeData<I>
+        where I : IPeak
+    {
+        public I Peak { get; }
+        public uint SampleID { get; }
+
+        public NodeData(I peak, uint sampleID)
+        {
+            Peak = peak;
+            SampleID = sampleID;
+        }
+    }
+}

--- a/Core/IntervalTree/NodeData.cs
+++ b/Core/IntervalTree/NodeData.cs
@@ -21,8 +21,6 @@ namespace Genometric.MSPC.Core.IntervalTree
 
         public int CompareTo(NodeData<I> other)
         {
-            int c = SampleID.CompareTo(other.SampleID);
-            if (c != 0) return c;
             return Peak.CompareTo(other.Peak);    
         }
     }

--- a/Core/IntervalTree/NodeData.cs
+++ b/Core/IntervalTree/NodeData.cs
@@ -21,7 +21,19 @@ namespace Genometric.MSPC.Core.IntervalTree
 
         public int CompareTo(NodeData<I> other)
         {
-            return Peak.CompareTo(other.Peak);    
+            int c = Peak.CompareTo(other.Peak);
+            if (c != 0) return c;
+            c = SampleID.CompareTo(other.SampleID);
+            if (c != 0) return c;
+            /// At this point two NodeData are
+            /// exactly same and does not matter
+            /// which one proceedds the other,
+            /// hence return -1 or 1. However, 
+            /// should not return 0, because 
+            /// that would fail adding them to
+            /// the intervals list (two items 
+            /// with same key). 
+            return -1;
         }
     }
 }

--- a/Core/IntervalTree/NodeData.cs
+++ b/Core/IntervalTree/NodeData.cs
@@ -3,10 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using Genometric.GeUtilities.IGenomics;
+using System;
 
 namespace Genometric.MSPC.Core.IntervalTree
 {
-    internal class NodeData<I>
+    internal class NodeData<I> : IComparable<NodeData<I>>
         where I : IPeak
     {
         public I Peak { get; }
@@ -16,6 +17,13 @@ namespace Genometric.MSPC.Core.IntervalTree
         {
             Peak = peak;
             SampleID = sampleID;
+        }
+
+        public int CompareTo(NodeData<I> other)
+        {
+            int c = SampleID.CompareTo(other.SampleID);
+            if (c != 0) return c;
+            return Peak.CompareTo(other.Peak);    
         }
     }
 }

--- a/Core/IntervalTree/Tree.cs
+++ b/Core/IntervalTree/Tree.cs
@@ -27,10 +27,9 @@ namespace Genometric.MSPC.Core.IntervalTree
             _inSync = false;
         }
 
-        public List<NodeData<I>> GetIntervals(I peak)
+        public List<NodeData<I>> GetIntervals(I peak, uint skipID)
         {
-            BuildAndFinalize();
-            return _head.Query(new NodeData<I>(peak, 0));
+            return _head.Query(new NodeData<I>(peak, 0), skipID);
         }
 
         public void BuildAndFinalize()

--- a/Core/IntervalTree/Tree.cs
+++ b/Core/IntervalTree/Tree.cs
@@ -10,34 +10,34 @@ namespace Genometric.MSPC.Core.IntervalTree
     internal class Tree<I>
         where I : IPeak
     {
-        private Node<I> _head;
-        private readonly List<I> _intervalList;
+        private Node<I, NodeData<I>> _head;
+        private readonly List<NodeData<I>> _intervalList;
         private bool _inSync;
 
         public Tree()
         {
-            _head = new Node<I>();
-            _intervalList = new List<I>();
+            _head = new Node<I, NodeData<I>>();
+            _intervalList = new List<NodeData<I>>();
             _inSync = true;
         }
 
-        public void Add(I interval)
+        public void Add(I interval, uint sampleID)
         {
-            _intervalList.Add(interval);
+            _intervalList.Add(new NodeData<I>(interval, sampleID));
             _inSync = false;
         }
 
-        public List<I> GetIntervals(I peak)
+        public List<NodeData<I>> GetIntervals(I peak)
         {
             BuildAndFinalize();
-            return _head.Query(peak);
+            return _head.Query(new NodeData<I>(peak, 0));
         }
 
         public void BuildAndFinalize()
         {
             if (!_inSync)
             {
-                _head = new Node<I>(_intervalList);
+                _head = new Node<I, NodeData<I>>(_intervalList);
                 /// If it is intended to only build this tree
                 /// without finalizing it, then remove the
                 /// following line.

--- a/Core/Model/Peak.cs
+++ b/Core/Model/Peak.cs
@@ -20,7 +20,7 @@ namespace Genometric.MSPC.Core.Model
             Source = source;
         }
 
-        public I Source { private set; get; }
+        public I Source { internal set; get; }
 
         public int CompareTo(Peak<I> other)
         {


### PR DESCRIPTION
Testing on a dataset that consists of 279 samples and 1,756,215 peaks: 

## CPU Optimization:
**63%** faster performance:

|     |  Runtime (seconds) |
| --- | --------: | 
| Before (dev branch) | 1,327| 
|  After (this PR)  | 488|



## Memory Optimization 
**59%** less objects, and **52%** smaller heap size. 

|     |  Objects   |    Heap Size  |
| -- | ----------: | --------------: |
| Before (dev branch) | 14,181,393 | 730,555.22 KB |
| After (this PR)   | 5,719,617  |  345,039.23 KB | 