### PR TITLE
Improve processing Supporting peaks.

### DIFF
--- a/Core/Functions/Processor.cs
+++ b/Core/Functions/Processor.cs
@@ -264,19 +264,19 @@ namespace Genometric.MSPC.Core.Functions
         {
             foreach (var supPeak in supportingPeaks)
             {
-                var tSupPeak = new List<SupportingPeak<I>>
-                {
-                    new SupportingPeak<I>(p, id)
-                };
-                foreach (var sP in supportingPeaks)
-                    if (supPeak.CompareTo(sP) != 0)
-                        tSupPeak.Add(sP);
-
                 ProcessedPeak<I> pp;
                 if (_trackSupportingRegions)
+                {
+                    var tSupPeak = new List<SupportingPeak<I>> { new SupportingPeak<I>(p, id) };
+                    foreach (var sP in supportingPeaks)
+                        if (supPeak.CompareTo(sP) != 0)
+                            tSupPeak.Add(sP);
                     pp = new ProcessedPeak<I>(supPeak.Source, xsqrd, tSupPeak);
+                }
                 else
-                    pp = new ProcessedPeak<I>(supPeak.Source, xsqrd, tSupPeak.Count);
+                {
+                    pp = new ProcessedPeak<I>(supPeak.Source, xsqrd, supportingPeaks.Count);
+                }
 
                 pp.AddClassification(attribute);
                 pp.reason = message;


### PR DESCRIPTION
## Performance Optimization
- **88%** (or **8.7x**) faster performance w.r.t https://github.com/Genometric/MSPC/pull/77;
- **95%** (or **23.7x**)  faster performance w.r.t. using one interval tree per sample (i.e., before https://github.com/Genometric/MSPC/pull/77).

|     |  Runtime (seconds) |
| --- | --------: | 
| Before PR https://github.com/Genometric/MSPC/pull/77 |  1,327 |
| With PR https://github.com/Genometric/MSPC/pull/77 | 488| 
|  This PR (built on https://github.com/Genometric/MSPC/pull/77)   | 56 |