### PR TITLE
Fix a bug truncating column content 

### DIFF
--- a/CLI.Tests/Table.cs
+++ b/CLI.Tests/Table.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the Genometric organization (https://github.com/Genometric) under one or more agreements.
+// The Genometric organization licenses this file to you under the GNU General Public License v3.0 (GPLv3).
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace Genometric.MSPC.CLI.Tests
+{
+    public class Table
+    {
+        [Theory]
+        [InlineData("aaaaaa", 5)]
+        [InlineData("aaaaaa", 4)]
+        [InlineData("aaaaaa", 3)]
+        [InlineData("aaaaaa", 2)]
+        [InlineData("aaaaaa", 1)]
+        public void ColumnWidthLessThanContentLenght(string content, int length)
+        {
+            // Arrange
+            var table = new Logging.Table(new int[] { length });
+
+            // Act
+            var row = table.GetRow(new string[] { content });
+
+            // Assert
+            Assert.Contains("...", row);
+        }
+    }
+}

--- a/CLI.Tests/Table.cs
+++ b/CLI.Tests/Table.cs
@@ -12,18 +12,17 @@ namespace Genometric.MSPC.CLI.Tests
         [InlineData("aaaaaa", 5)]
         [InlineData("aaaaaa", 4)]
         [InlineData("aaaaaa", 3)]
-        [InlineData("aaaaaa", 2)]
-        [InlineData("aaaaaa", 1)]
         public void ColumnWidthLessThanContentLenght(string content, int length)
         {
             // Arrange
             var table = new Logging.Table(new int[] { length });
 
             // Act
-            var row = table.GetRow(new string[] { content });
+            var row = table.GetRow(new string[] { content }).Replace('\t', ' ').Trim();
 
             // Assert
             Assert.Contains("...", row);
+            Assert.Equal(row.Length, length);
         }
     }
 }

--- a/CLI.Tests/Table.cs
+++ b/CLI.Tests/Table.cs
@@ -24,5 +24,21 @@ namespace Genometric.MSPC.CLI.Tests
             Assert.Contains("...", row);
             Assert.Equal(row.Length, length);
         }
+
+        [Theory]
+        [InlineData("aaaaaa", 8)]
+        [InlineData("aaaaaa", 7)]
+        [InlineData("aaaaaa", 6)]
+        public void ShouldNotTruncateWhenEnoughSpaceAvailable(string content, int length)
+        {
+            // Arrange
+            var table = new Logging.Table(new int[] { length });
+
+            // Act
+            var row = table.GetRow(new string[] { content }).Replace('\t', ' ').Trim();
+
+            // Assert
+            Assert.DoesNotContain("...", row);
+        }
     }
 }

--- a/CLI/Logging/Logger.cs
+++ b/CLI/Logging/Logger.cs
@@ -153,7 +153,7 @@ namespace Genometric.MSPC.CLI.Logging
         public void InitializeLoggingParser(int samplesCount)
         {
             var columnsWidth = new int[] { IdxColChars(samplesCount), _fileNameMaxLenght, 11, 11, 12, 11 };
-            _parserLogTable = new Table(columnsWidth, _repository, _name);
+            _parserLogTable = new Table(columnsWidth);
             _parserLogTable.AddHeader(new string[]
             {
                 "#", "Filename", "Read peaks#", "Min p-value", "Mean p-value", "Max p-value"
@@ -206,7 +206,7 @@ namespace Genometric.MSPC.CLI.Logging
                 headerColumns[i] = exportedAttributes[i - 3].ToString();
                 columnsWidth[i] = headerColumns[i].Length > 8 ? headerColumns[i].Length : 8;
             }
-            var table = new Table(columnsWidth, _repository, _name);
+            var table = new Table(columnsWidth);
             table.AddHeader(headerColumns);
 
             // Per sample stats

--- a/CLI/Logging/Logger.cs
+++ b/CLI/Logging/Logger.cs
@@ -169,7 +169,7 @@ namespace Genometric.MSPC.CLI.Logging
             double meanPValue,
             double maxPValue)
         {
-            _parserLogTable.AddRow(new string[]
+            var row = _parserLogTable.GetRow(new string[]
             {
                 IdxColFormat(fileNumber, filesToParse),
                 filename,
@@ -178,6 +178,9 @@ namespace Genometric.MSPC.CLI.Logging
                 string.Format("{0:E3}", meanPValue),
                 string.Format("{0:E3}", maxPValue)
             });
+
+            Console.WriteLine(row);
+            log.Info(row);
         }
 
         public void LogSummary(
@@ -223,7 +226,10 @@ namespace Genometric.MSPC.CLI.Logging
                         value += chr.Value.Count(att);
                     sampleSummary[i++] = (value / totalPeaks).ToString("P");
                 }
-                table.AddRow(sampleSummary);
+
+                var row = table.GetRow(sampleSummary);
+                Console.WriteLine(row);
+                log.Info(row);
             }
         }
     }

--- a/CLI/Logging/Table.cs
+++ b/CLI/Logging/Table.cs
@@ -2,7 +2,6 @@
 // The Genometric organization licenses this file to you under the GNU General Public License v3.0 (GPLv3).
 // See the LICENSE file in the project root for more information.
 
-using log4net;
 using System;
 using System.Text;
 
@@ -11,12 +10,10 @@ namespace Genometric.MSPC.CLI.Logging
     internal class Table
     {
         private readonly int[] _columnsWidth;
-        private readonly ILog log;
 
-        public Table(int[] columnsWidth, string repository, string name)
+        public Table(int[] columnsWidth)
         {
             _columnsWidth = columnsWidth;
-            log = LogManager.GetLogger(repository, name);
         }
 
         public void AddHeader(params string[] headers)

--- a/CLI/Logging/Table.cs
+++ b/CLI/Logging/Table.cs
@@ -66,7 +66,7 @@ namespace Genometric.MSPC.CLI.Logging
             if (value.Length <= maxLength)
                 return value.PadLeft(maxLength);
             else
-                return "..." + value.Substring(value.Length - maxLength - 3, maxLength);
+                return "..." + value.Substring(value.Length - (maxLength - 3));
         }
     }
 }

--- a/CLI/Logging/Table.cs
+++ b/CLI/Logging/Table.cs
@@ -28,11 +28,9 @@ namespace Genometric.MSPC.CLI.Logging
             Console.WriteLine(RenderRow(headerLines));
         }
 
-        public void AddRow(params string[] columns)
+        public string GetRow(params string[] columns)
         {
-            string row = RenderRow(columns);
-            Console.WriteLine(row);
-            log.Info(row);
+            return RenderRow(columns);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR implements: 

- makes table independent from the logger, hence it does not log directly rather it returns the message to be logged to the logger itself;
- fixes a bug truncating the content of a table column; 
- adds unit tests for the `Table` class. 

Fixes https://github.com/Genometric/MSPC/issues/81