### PR TITLE
Drop SonarScanner preview mode

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ clone_depth: 1
 
 build_script:
   - choco install "msbuild-sonarqube-runner" -y
-  - SonarScanner.MSBuild.exe begin /k:"mspc" /o:"genometric" /d:"sonar.host.url=https://sonarcloud.io" /d:"sonar.analysis.mode=preview"
+  - SonarScanner.MSBuild.exe begin /k:"mspc" /o:"genometric" /d:"sonar.host.url=https://sonarcloud.io"
   - MSBuild.exe /t:Rebuild
   - SonarScanner.MSBuild.exe end 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,12 +17,6 @@ build:
   verbosity: minimal
 clone_depth: 1
 
-build_script:
-  - choco install "msbuild-sonarqube-runner" -y
-  - SonarScanner.MSBuild.exe begin /k:"mspc" /o:"genometric" /d:"sonar.host.url=https://sonarcloud.io"
-  - MSBuild.exe /t:Rebuild
-  - SonarScanner.MSBuild.exe end 
-
 test_script:
   # restore packages for our unit tests
   - cmd: dotnet restore Core.Tests\Core.Tests.csproj --verbosity m


### PR DESCRIPTION
This will fix the following error: the preview mode, along with the 'sonar.analysis.mode' parameter, is no more supported. You should stop using this parameter.