### PR TITLE
Formatting and colouring error and success messages.

### DIFF
--- a/CLI.Tests/CLIOptions.cs
+++ b/CLI.Tests/CLIOptions.cs
@@ -348,7 +348,7 @@ namespace Genometric.MSPC.CLI.Tests
 
             // Assert
             var exception = Assert.Throws<ArgumentException>(() => options.Parse(arguments, out bool _));
-            Assert.Equal("The following required arguments are missing: r|replicate; ", exception.Message);
+            Assert.Equal("the following required arguments are missing: r|replicate; ", exception.Message);
         }
 
         [Fact]

--- a/CLI.Tests/Main.cs
+++ b/CLI.Tests/Main.cs
@@ -25,7 +25,7 @@ namespace Genometric.MSPC.CLI.Tests
                 msg = tmpMspc.Run(false, "-i rep1.bed -r bio -w 1E-2 -s 1E-8");
 
             // Assert
-            Assert.Contains("At least two samples are required; 1 is given.", msg);
+            Assert.Contains("at least two samples are required; 1 is given.", msg);
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace Genometric.MSPC.CLI.Tests
                 msg = tmpMspc.Run(false, "-i rep1.bed -i rep2.bed -w 1E-2 -s 1E-8");
 
             // Assert
-            Assert.Contains("The following required arguments are missing: r|replicate;", msg);
+            Assert.Contains("the following required arguments are missing: r|replicate;", msg);
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace Genometric.MSPC.CLI.Tests
                 msg = tmpMspc.Run(false, "-i rep1.bed -i rep2.bed -r bio -w 1E-2 -s 1E-8");
 
             // Assert
-            Assert.Contains("The following files are missing: rep1.bed; rep2.bed", msg);
+            Assert.Contains("the following files are missing: rep1.bed; rep2.bed", msg);
         }
 
         [Fact]
@@ -238,8 +238,8 @@ namespace Genometric.MSPC.CLI.Tests
                 messages = tmpMspc.FailRun();
 
             // Assert
-            Assert.Contains(messages, x => x.Contains("The following files are missing: rep1; rep2"));
-            Assert.Contains(messages, x => x.Contains("The following required arguments are missing: i|input"));
+            Assert.Contains(messages, x => x.Contains("the following files are missing: rep1; rep2"));
+            Assert.Contains(messages, x => x.Contains("the following required arguments are missing: i|input"));
         }
 
         [Fact]
@@ -267,7 +267,7 @@ namespace Genometric.MSPC.CLI.Tests
                 messages = tmpMspc.FailRun(template2: "-i rep1 -i rep2 -o C:\\*<>*\\// -r bio -s 1e-8 -w 1e-4");
 
             // Assert
-            Assert.Contains(messages, x => x.Contains("The following files are missing: rep1; rep2"));
+            Assert.Contains(messages, x => x.Contains("the following files are missing: rep1; rep2"));
             Assert.Contains(messages, x => x.Contains("Illegal characters in path."));
         }
 

--- a/CLI.Tests/ParserConfig.cs
+++ b/CLI.Tests/ParserConfig.cs
@@ -102,7 +102,7 @@ namespace Genometric.MSPC.CLI.Tests
             Assert.Contains(
                 log, 
                 x => x.Contains(
-                    "Error reading parser configuration JSON object: Newtonsoft.Json.JsonReaderException: " +
+                    "error reading parser configuration JSON object: Newtonsoft.Json.JsonReaderException: " +
                     "Unexpected character encountered while parsing value"));
         }
 
@@ -137,7 +137,7 @@ namespace Genometric.MSPC.CLI.Tests
             Assert.Contains(
                 log,
                 x => x.Contains(
-                    "Error reading parser configuration " +
+                    "error reading parser configuration " +
                     "JSON object, check if the given file"));
         }
 

--- a/CLI/CommandLineOptions.cs
+++ b/CLI/CommandLineOptions.cs
@@ -152,7 +152,7 @@ namespace Genometric.MSPC.CLI
 
             if (missingArgs.Count > 0)
             {
-                var msgBuilder = new StringBuilder("The following required arguments are missing: ");
+                var msgBuilder = new StringBuilder("the following required arguments are missing: ");
                 foreach (var item in missingArgs)
                     msgBuilder.Append(item + "; ");
                 throw new ArgumentException(msgBuilder.ToString());

--- a/CLI/Logging/Logger.cs
+++ b/CLI/Logging/Logger.cs
@@ -22,7 +22,7 @@ namespace Genometric.MSPC.CLI.Logging
     {
         private readonly int _sectionHeaderLenght = 30;
         private readonly int _fileNameMaxLenght = 20;
-        private readonly string _cannotContinue = "MSPC cannot continue.";
+        private static readonly string _cannotContinue = "MSPC cannot continue.";
         private bool _lastStatusUpdatedItsPrevious;
         private Table _parserLogTable;
 
@@ -86,12 +86,17 @@ namespace Genometric.MSPC.CLI.Logging
 
         public void LogException(string message)
         {
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.WriteLine(message);
-            Console.ResetColor();
-            Console.WriteLine(_cannotContinue);
+            LogExceptionStatic(message);
             log.Error(message);
             log.Info(_cannotContinue);
+        }
+
+        public static void LogExceptionStatic(string message)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine(string.Format("Error: {0}", message));
+            Console.ResetColor();
+            Console.WriteLine(_cannotContinue);
         }
 
         public void LogMSPCStatus(object sender, ValueEventArgs e)

--- a/CLI/Logging/Logger.cs
+++ b/CLI/Logging/Logger.cs
@@ -140,11 +140,12 @@ namespace Genometric.MSPC.CLI.Logging
             log.Info(message);
         }
 
-        public void LogFinish()
+        public void LogFinish(string message = "All processes successfully finished.")
         {
-            string msg = "All processes successfully finished";
-            Console.WriteLine(Environment.NewLine + msg + Environment.NewLine);
-            log.Info(msg);
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine(Environment.NewLine + message + Environment.NewLine);
+            Console.ResetColor();
+            log.Info(message);
         }
 
         public void ShutdownLogger()

--- a/CLI/Logging/Logger.cs
+++ b/CLI/Logging/Logger.cs
@@ -20,7 +20,7 @@ namespace Genometric.MSPC.CLI.Logging
 {
     public class Logger
     {
-        private readonly int _sectionHeaderLenght = 30;
+        private readonly int _sectionHeaderLenght = 20;
         private readonly int _fileNameMaxLenght = 20;
         private static readonly string _cannotContinue = "MSPC cannot continue.";
         private bool _lastStatusUpdatedItsPrevious;
@@ -73,8 +73,8 @@ namespace Genometric.MSPC.CLI.Logging
         public void LogStartOfASection(string header)
         {
             string msg = ".::." + header.PadLeft(((_sectionHeaderLenght - header.Length) / 2) + header.Length, '.').PadRight(_sectionHeaderLenght, '.') + ".::.";
-            Console.ForegroundColor = ConsoleColor.Green;
-            Console.WriteLine(Environment.NewLine + msg + Environment.NewLine);
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine(Environment.NewLine + msg);
             Console.ResetColor();
             log.Info(msg);
         }

--- a/CLI/Orchestrator.cs
+++ b/CLI/Orchestrator.cs
@@ -92,7 +92,7 @@ namespace Genometric.MSPC.CLI
             catch (Exception e)
             {
                 if (_logger == null)
-                    Console.WriteLine(e.Message);
+                    Logger.LogExceptionStatic(e.Message);
                 else
                     _logger.LogException(e);
                 return false;
@@ -129,7 +129,7 @@ namespace Genometric.MSPC.CLI
             catch (Exception e)
             {
                 if (_logger == null)
-                    Console.WriteLine(e.Message);
+                    Logger.LogExceptionStatic(e.Message);
                 else
                     _logger.LogException(e);
                 return false;
@@ -150,7 +150,7 @@ namespace Genometric.MSPC.CLI
             }
             catch (Exception e)
             {
-                Console.WriteLine(e.Message);
+                Logger.LogExceptionStatic(e.Message);
                 return false;
             }
         }
@@ -160,7 +160,7 @@ namespace Genometric.MSPC.CLI
             if (input.Count < 2)
             {
                 _logger.LogException(
-                    string.Format("At least two samples are required; {0} is given.", input.Count));
+                    string.Format("at least two samples are required; {0} is given.", input.Count));
                 return false;
             }
 
@@ -171,7 +171,7 @@ namespace Genometric.MSPC.CLI
             if (missingFiles.Count > 0)
             {
                 _logger.LogException(
-                    string.Format("The following files are missing: {0}", string.Join("; ", missingFiles.ToArray())));
+                    string.Format("the following files are missing: {0}", string.Join("; ", missingFiles.ToArray())));
                 return false;
             }
 
@@ -197,7 +197,7 @@ namespace Genometric.MSPC.CLI
                     if (config == null)
                     {
                         _logger.LogException(string.Format(
-                            "Error reading parser configuration JSON object, " +
+                            "error reading parser configuration JSON object, " +
                             "check if the given file '{0}' exists and is accessible.",
                             options.ParserConfig));
                         return false;
@@ -205,7 +205,7 @@ namespace Genometric.MSPC.CLI
                 }
                 catch (Exception e)
                 {
-                    _logger.LogException("Error reading parser configuration JSON object: " + e);
+                    _logger.LogException("error reading parser configuration JSON object: " + e);
                     return false;
                 }
             }
@@ -247,7 +247,7 @@ namespace Genometric.MSPC.CLI
             catch (Exception e)
             {
                 samples = null;
-                _logger.LogException("Error parsing data: " + e.Message);
+                _logger.LogException("error parsing data: " + e.Message);
                 return false;
             }
         }


### PR DESCRIPTION
- Write all exceptions messages in _red_ color; 
- Implement an static logger method to be used when logger is not available; 
- Add `Error: ` prefix to all exception messages; 
- Set the colour of section title to _yellow_ and remove following blank line;
- Write the finish message in _green_.