### PR TITLE
Report elapsed time in the output.

### DIFF
--- a/CLI.Tests/Main.cs
+++ b/CLI.Tests/Main.cs
@@ -103,6 +103,20 @@ namespace Genometric.MSPC.CLI.Tests
         }
 
         [Fact]
+        public void ReportRuntime()
+        {
+            // Arrange
+            string msg;
+
+            // Act
+            using (var tmpMspc = new TmpMspc())
+                msg = tmpMspc.Run();
+
+            // Assert
+            Assert.Contains("Elapsed time: ", msg);
+        }
+
+        [Fact]
         public void SuccessfulAnalysis()
         {
             // Arrange

--- a/CLI/Logging/Logger.cs
+++ b/CLI/Logging/Logger.cs
@@ -141,12 +141,14 @@ namespace Genometric.MSPC.CLI.Logging
             log.Info(message);
         }
 
-        public void LogFinish(string message = "All processes successfully finished.")
+        public void LogFinish(string elapsedTime, string message = "All processes successfully finished.")
         {
             Console.ForegroundColor = ConsoleColor.Green;
-            Console.WriteLine(Environment.NewLine + message + Environment.NewLine);
+            Console.WriteLine(Environment.NewLine);
+            Log($"Elapsed time: {elapsedTime}");
+            Log(message);
+            Console.WriteLine(Environment.NewLine);
             Console.ResetColor();
-            log.Info(message);
         }
 
         public void ShutdownLogger()

--- a/CLI/Orchestrator.cs
+++ b/CLI/Orchestrator.cs
@@ -12,6 +12,7 @@ using Genometric.MSPC.Core;
 using Genometric.MSPC.Core.Model;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -38,6 +39,9 @@ namespace Genometric.MSPC.CLI
 
         public void Orchestrate(string[] args)
         {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
             if (!ParseArgs(args, out CommandLineOptions options))
                 return;
 
@@ -75,7 +79,8 @@ namespace Genometric.MSPC.CLI
                 cPeaksCount += chr.Value.Count;
             _logger.Log(cPeaksCount.ToString("N0"));
 
-            _logger.LogFinish();
+            stopwatch.Stop();
+            _logger.LogFinish(stopwatch.Elapsed.ToString());
         }
 
         private bool ParseArgs(string[] args, out CommandLineOptions options)


### PR DESCRIPTION
Reports elapsed time as the following in the output: 

```
Elapsed time: 00:00:03.2534564
All processes successfully finished.
```
