### PR TITLE
Remove annotation files stored via LFS

### DIFF
--- a/ValidationScripts/hg19_annotations/hg19.conf.txt
+++ b/ValidationScripts/hg19_annotations/hg19.conf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ba11289eae8ffc71b63ad7e463412f31c98ef24f90e2b0081d28b97b1e20e20a
-size 997

--- a/ValidationScripts/hg19_annotations/merged/CpG_islands_hg19.mrg.txt
+++ b/ValidationScripts/hg19_annotations/merged/CpG_islands_hg19.mrg.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6c5ae2f9d2e1276c990aa4bd425f79c0293ba1c97e1e5145c7561b309afdd972
-size 656967

--- a/ValidationScripts/hg19_annotations/merged/Enhancers_hg19.mrg.txt
+++ b/ValidationScripts/hg19_annotations/merged/Enhancers_hg19.mrg.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:abc340af9a0717a109d7c81d5b1d0a318f021a71566f93eeaa0ddf6f37cad8d6
-size 5424028

--- a/ValidationScripts/hg19_annotations/merged/KnownGenes_hg19_exons.mrg.txt
+++ b/ValidationScripts/hg19_annotations/merged/KnownGenes_hg19_exons.mrg.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0bce76880c7bf398788751ae392fccd3622ff78e956b68e193eee65e6d5bac3d
-size 5805148

--- a/ValidationScripts/hg19_annotations/merged/KnownGenes_hg19_introns.mrg.txt
+++ b/ValidationScripts/hg19_annotations/merged/KnownGenes_hg19_introns.mrg.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:44bd1b2cf887d6123600e5fe604708997cb7c9feff2ffc9d0b67f4088e2d99b5
-size 4154946

--- a/ValidationScripts/hg19_annotations/merged/KnownTranscripts_hg19_coding.mrg.txt
+++ b/ValidationScripts/hg19_annotations/merged/KnownTranscripts_hg19_coding.mrg.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:23dc4fd6bf1ebd0d8ada5b276768bf0eef40c633ee5f094ab11ad27e717402da
-size 402111

--- a/ValidationScripts/hg19_annotations/merged/KnownTranscripts_hg19_nonCoding.mrg.txt
+++ b/ValidationScripts/hg19_annotations/merged/KnownTranscripts_hg19_nonCoding.mrg.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b278124dcce0c56024ff7721dbf67f707823e799786b0d160a6948584d07683
-size 91967

--- a/ValidationScripts/hg19_annotations/merged/KnownTranscripts_hg19_nonRefSeq.mrg.txt
+++ b/ValidationScripts/hg19_annotations/merged/KnownTranscripts_hg19_nonRefSeq.mrg.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f5706814e23c1d87faa847a4fd42202e543f4ddebb03a4f24cba46708e445bcd
-size 311629

--- a/ValidationScripts/hg19_annotations/merged/KnownTranscripts_hg19_promoters.mrg.txt
+++ b/ValidationScripts/hg19_annotations/merged/KnownTranscripts_hg19_promoters.mrg.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e676ef4414e525e17f77a5985ab03acb9fd152001e257121d96e1d13092b99a
-size 631861

--- a/ValidationScripts/hg19_annotations/merged/miRNA_hg19.mrg.txt
+++ b/ValidationScripts/hg19_annotations/merged/miRNA_hg19.mrg.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f76406870867c11a19e5522065aff5f3a96ecf9645ad5f1f1e0e0307d8eff89e
-size 22241

--- a/ValidationScripts/hg19_annotations/merged/snoRNA_hg19.mrg.txt
+++ b/ValidationScripts/hg19_annotations/merged/snoRNA_hg19.mrg.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:65304a3e3c4597917f92c5286234f17c140b257c34d556c6a796650327051271
-size 9635

--- a/ValidationScripts/hg19_annotations/merged/tRNA_hg19.mrg.txt
+++ b/ValidationScripts/hg19_annotations/merged/tRNA_hg19.mrg.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ace2b9df89ab7aa676970ec52ee0366bb6d5201295e332f59348f4f8eacd29aa
-size 14362

--- a/ValidationScripts/hg38_annotations/hg38.conf.txt
+++ b/ValidationScripts/hg38_annotations/hg38.conf.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3d9da565948465d27c68c005ba528a1f6e1b845c9614ef5a9aec16cd6649a488
-size 1119

--- a/ValidationScripts/hg38_annotations/merged/CpG_islands_hg38.bed
+++ b/ValidationScripts/hg38_annotations/merged/CpG_islands_hg38.bed
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:77621b34c5913b6605d8967edff76ad0d39d32d44ef1d22ea104c1ee860b4383
-size 772175

--- a/ValidationScripts/hg38_annotations/merged/Enhancers_hg19_to_hg38.bed
+++ b/ValidationScripts/hg38_annotations/merged/Enhancers_hg19_to_hg38.bed
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:82a9fda2497bfaae118a6bea06cfe5596fe3d4c885c43ec8f0f0afb97eb92b9b
-size 5422070

--- a/ValidationScripts/hg38_annotations/merged/KnownGene_Gencode29_hg38_RefSeq_coding.bed
+++ b/ValidationScripts/hg38_annotations/merged/KnownGene_Gencode29_hg38_RefSeq_coding.bed
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eda85bc7003f038dbd7e0c1bb45ecc7604956136371b98d7b1538f76d2c21e68
-size 411916

--- a/ValidationScripts/hg38_annotations/merged/KnownGene_Gencode29_hg38_RefSeq_noncoding.bed
+++ b/ValidationScripts/hg38_annotations/merged/KnownGene_Gencode29_hg38_RefSeq_noncoding.bed
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a304a45565c5dfce17980065fd958b94e4ae2295d76c0c944ef7695fdf89780
-size 196607

--- a/ValidationScripts/hg38_annotations/merged/KnownGene_Gencode29_hg38_exons.bed
+++ b/ValidationScripts/hg38_annotations/merged/KnownGene_Gencode29_hg38_exons.bed
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:07440b1ea4d51317b93d24c8ba9a58c8245b25aa995915ae75b599fea7850bb2
-size 7477656

--- a/ValidationScripts/hg38_annotations/merged/KnownGene_Gencode29_hg38_introns.bed
+++ b/ValidationScripts/hg38_annotations/merged/KnownGene_Gencode29_hg38_introns.bed
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cab11a4692c998c52933a2c6a861f730db223cb6435f79a6d5d5b605308eff58
-size 4122065

--- a/ValidationScripts/hg38_annotations/merged/KnownGene_Gencode29_hg38_nonRefSeq.bed
+++ b/ValidationScripts/hg38_annotations/merged/KnownGene_Gencode29_hg38_nonRefSeq.bed
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5effe3023a3c47862722a2806212bac1ed5b23fe828abf3ef88563c3f6d9f2cf
-size 834838

--- a/ValidationScripts/hg38_annotations/merged/KnownGene_Gencode29_hg38_promoters.bed
+++ b/ValidationScripts/hg38_annotations/merged/KnownGene_Gencode29_hg38_promoters.bed
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a1e55114ff05b20eaf3e724b9285d7d18675b76c7dd7291ba720c1e210e37875
-size 1614370

--- a/ValidationScripts/hg38_annotations/merged/miRNA_hg38.bed
+++ b/ValidationScripts/hg38_annotations/merged/miRNA_hg38.bed
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55aaed869cafa7234202bb0a087c1d67c3fcf636e74d1c2e4c2052af9a6b1bf0
-size 44564

--- a/ValidationScripts/hg38_annotations/merged/snoRNA_hg38.bed
+++ b/ValidationScripts/hg38_annotations/merged/snoRNA_hg38.bed
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:49bdeb10be32459469b7bac665c33e6784f557dc691586fb11a6d4ca78d0e71c
-size 9635

--- a/ValidationScripts/hg38_annotations/merged/tRNA_hg38.bed
+++ b/ValidationScripts/hg38_annotations/merged/tRNA_hg38.bed
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cba51781d48812237783d190d21144e697b0cbcb5937b6c68846e8071f004497
-size 15041


### PR DESCRIPTION
Annotations are moved to this repository: https://github.com/Genometric/Annotations

ping @fernandoPalluzzi @marziacremona 