### PR TITLE
Report `inf` as a result of converting 0 to -Log10 format

### DIFF
--- a/CLI.Tests/CLI.Tests.csproj
+++ b/CLI.Tests/CLI.Tests.csproj
@@ -9,7 +9,7 @@
 
     <RootNamespace>Genometric.MSPC.CLI.Tests</RootNamespace>
 
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
 
     <Authors>Vahid Jalili</Authors>
 
@@ -27,9 +27,9 @@
 
     <Company>Genometric</Company>
 
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
 
-    <FileVersion>4.0.1.0</FileVersion>
+    <FileVersion>4.0.2.0</FileVersion>
 
     <PackageTags>Next-Generation-Sequencing; NGS-analysis; ChIP-seq; genome-analysis; Peak-calling; Comparative-Peak-Calling; Replicates; Single-Cell; ATAC-seq; biological-replicates; technical-replicates</PackageTags>
 

--- a/CLI/CLI.csproj
+++ b/CLI/CLI.csproj
@@ -6,7 +6,7 @@
     <StartupObject>Genometric.MSPC.CLI.Program</StartupObject>
     <ApplicationIcon />
     <Win32Resource />
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
     <Authors>Vahid Jalili</Authors>
     <Product>Genometric.MSPC.CLI</Product>
     <PackageProjectUrl>https://genometric.github.io/MSPC/</PackageProjectUrl>

--- a/CLI/Export/Exporter.cs
+++ b/CLI/Export/Exporter.cs
@@ -140,15 +140,12 @@ namespace Genometric.MSPC.CLI.Exporter
 
         private string ConvertPValue(double pValue)
         {
-            /// When p-value=0, the result of this conversion is Infinity,
-            /// hence to avoid exporting `Infinity` that may not be an 
-            /// acceptable input by some tools, MSPC reports 0 instead.
             if (pValue != 0)
                 return
                     (Math.Round((-1) * Math.Log10(pValue), 3))
                     .ToString(CultureInfo.CreateSpecificCulture(
                         CultureInfo.CurrentCulture.Name));
-            return "0";
+            return "inf";
         }
     }
 }

--- a/Core.Tests/Core.Tests.csproj
+++ b/Core.Tests/Core.Tests.csproj
@@ -19,13 +19,13 @@
 
     <RepositoryUrl>https://github.com/Genometric/MSPC</RepositoryUrl>
 
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.21.0</AssemblyVersion>
 
     <Copyright>GNU General Public License v3.0</Copyright>
 
     <Description>Using combined evidence from replicates to evaluate ChIP-seq peaks</Description>
 
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
 
     <Company>Genometric</Company>
 

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl></PackageLicenseUrl>
     <PackageProjectUrl>https://genometric.github.io/MSPC/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Genometric/MSPC</RepositoryUrl>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <Copyright>GNU General Public License v3.0</Copyright>
     <Description>Using combined evidence from replicates to evaluate ChIP-seq peaks</Description>
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Genometric</Company>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
Addresses the issue reported at https://github.com/Genometric/MSPC/issues/131.