### PR TITLE
Set ExitCode according to the termination status

### DIFF
--- a/CLI.Tests/Main.cs
+++ b/CLI.Tests/Main.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Genometric.GeUtilities.Intervals.Parsers;
-using Genometric.MSPC.CLI.Logging;
 using Genometric.MSPC.CLI.Tests.MockTypes;
 using Newtonsoft.Json;
 using System;
@@ -28,6 +27,7 @@ namespace Genometric.MSPC.CLI.Tests
 
             // Assert
             Assert.Contains("at least two samples are required; 1 is given.", msg);
+            Assert.False(Environment.ExitCode == 0);
         }
 
         [Fact]
@@ -42,6 +42,7 @@ namespace Genometric.MSPC.CLI.Tests
 
             // Assert
             Assert.Contains("the following required arguments are missing: -r|--replicate.", msg);
+            Assert.False(Environment.ExitCode == 0);
         }
 
         [Fact]
@@ -56,6 +57,7 @@ namespace Genometric.MSPC.CLI.Tests
 
             // Assert
             Assert.Contains("the following files are missing: rep1.bed; rep2.bed", msg);
+            Assert.False(Environment.ExitCode == 0);
         }
 
         [Fact]
@@ -129,6 +131,7 @@ namespace Genometric.MSPC.CLI.Tests
 
             // Assert
             Assert.Contains("All processes successfully finished", msg);
+            Assert.True(Environment.ExitCode == 0);
         }
 
         [Fact]
@@ -209,6 +212,7 @@ namespace Genometric.MSPC.CLI.Tests
                 Assert.Null(reader.ReadLine());
             }
 
+            Assert.True(Environment.ExitCode == 0);
             Assert.True(Directory.GetFiles(dirs[1]).Length == 14);
             using (var reader = new StreamReader(Directory.GetFiles(dirs[1], "*TruePositive.bed")[0]))
             {
@@ -262,6 +266,7 @@ namespace Genometric.MSPC.CLI.Tests
 
             // Assert
             Assert.Contains(expected, msg);
+            Assert.True(Environment.ExitCode == 0);
         }
 
         [Theory]
@@ -279,6 +284,7 @@ namespace Genometric.MSPC.CLI.Tests
 
             // Assert
             Assert.Contains(expected, msg);
+            Assert.True(Environment.ExitCode == 0);
         }
 
         [Fact]
@@ -294,6 +300,7 @@ namespace Genometric.MSPC.CLI.Tests
 
             // Assert
             Assert.Contains(expected, msg);
+            Assert.False(Environment.ExitCode == 0);
         }
 
         [Fact]
@@ -354,6 +361,7 @@ namespace Genometric.MSPC.CLI.Tests
             Assert.True(
                 msg.Contains("Illegal characters in path.") ||
                 msg.Contains("The filename, directory name, or volume label syntax is incorrect"));
+            Assert.False(Environment.ExitCode == 0);
         }
 
         [Fact]
@@ -401,6 +409,7 @@ namespace Genometric.MSPC.CLI.Tests
                 messages,
                 x => x.Contains("Illegal characters in path.") ||
                 x.Contains("The filename, directory name, or volume label syntax is incorrect"));
+            Assert.False(Environment.ExitCode == 0);
         }
 
         [Fact]
@@ -416,6 +425,7 @@ namespace Genometric.MSPC.CLI.Tests
             // Assert
             Assert.Contains("The method or operation is not implemented.", message);
             Assert.DoesNotContain("All processes successfully finished", message);
+            Assert.False(Environment.ExitCode == 0);
         }
 
         [Fact]
@@ -446,6 +456,7 @@ namespace Genometric.MSPC.CLI.Tests
 
             // Assert
             Assert.Contains("Input string was not in a correct format.", output);
+            Assert.False(Environment.ExitCode == 0);
         }
 
         [Fact]
@@ -524,6 +535,7 @@ namespace Genometric.MSPC.CLI.Tests
             Assert.Contains(messages, x =>
             x.Contains("The process cannot access the file") &&
             x.Contains("because it is being used by another process."));
+            Assert.False(Environment.ExitCode == 0);
 
             // Clean up
             File.Delete(rep1Path);

--- a/CLI/Orchestrator.cs
+++ b/CLI/Orchestrator.cs
@@ -100,6 +100,7 @@ namespace Genometric.MSPC.CLI
                     Logger.LogExceptionStatic(e.Message);
                 else
                     _logger.LogException(e);
+                Environment.ExitCode = 1;
                 return false;
             }
         }
@@ -137,6 +138,7 @@ namespace Genometric.MSPC.CLI
                     Logger.LogExceptionStatic(e.Message);
                 else
                     _logger.LogException(e);
+                Environment.ExitCode = 1;
                 return false;
             }
         }
@@ -156,6 +158,7 @@ namespace Genometric.MSPC.CLI
             catch (Exception e)
             {
                 Logger.LogExceptionStatic(e.Message);
+                Environment.ExitCode = 1;
                 return false;
             }
         }
@@ -166,6 +169,7 @@ namespace Genometric.MSPC.CLI
             {
                 _logger.LogException(
                     string.Format("at least two samples are required; {0} is given.", input.Count));
+                Environment.ExitCode = 1;
                 return false;
             }
 
@@ -177,6 +181,7 @@ namespace Genometric.MSPC.CLI
             {
                 _logger.LogException(
                     string.Format("the following files are missing: {0}", string.Join("; ", missingFiles.ToArray())));
+                Environment.ExitCode = 1;
                 return false;
             }
 
@@ -211,6 +216,7 @@ namespace Genometric.MSPC.CLI
                 catch (Exception e)
                 {
                     _logger.LogException("error reading parser configuration JSON object: " + e.Message);
+                    Environment.ExitCode = 1;
                     return false;
                 }
             }
@@ -254,6 +260,7 @@ namespace Genometric.MSPC.CLI
             {
                 samples = null;
                 _logger.LogException("error parsing data: " + e.Message);
+                Environment.ExitCode = 1;
                 return false;
             }
         }
@@ -278,6 +285,7 @@ namespace Genometric.MSPC.CLI
             {
                 mspc = null;
                 _logger.LogException(e);
+                Environment.ExitCode = 1;
                 return false;
             }
         }
@@ -300,6 +308,7 @@ namespace Genometric.MSPC.CLI
             catch (Exception e)
             {
                 _logger.LogException(e);
+                Environment.ExitCode = 1;
                 return false;
             }
         }

--- a/CLI/Program.cs
+++ b/CLI/Program.cs
@@ -2,6 +2,7 @@
 // The Genometric organization licenses this file to you under the GNU General Public License v3.0 (GPLv3).
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Genometric.MSPC.CLI.Tests")]
@@ -11,6 +12,7 @@ namespace Genometric.MSPC.CLI
     {
         public static void Main(string[] args)
         {
+            Environment.ExitCode = 0;
             using (var orchestrator = new Orchestrator())
                 orchestrator.Orchestrate(args);
         }


### PR DESCRIPTION
Xref: https://github.com/Genometric/MSPC/issues/142

Sets exit code (`Environment.ExitCode`) as it follows: 

| Status         | Exit Code  |
| ------------ | ----------- |
| Successful  | `0`             |
| Error           | `1`             |