### PR TITLE
Adjust maximum value of C according to the number of given input samples

### DIFF
--- a/CLI.Tests/CLI.Tests.csproj
+++ b/CLI.Tests/CLI.Tests.csproj
@@ -69,10 +69,6 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-	<None Include="..\website\static\img\logo.png">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-	</None>
   </ItemGroup>
 
 </Project>

--- a/CLI.Tests/CLIOptions.cs
+++ b/CLI.Tests/CLIOptions.cs
@@ -260,7 +260,7 @@ namespace Genometric.MSPC.CLI.Tests
         [Theory]
         [InlineData(_c)]
         [InlineData("1")]
-        [InlineData("5")]
+        [InlineData("3")]
         public void ReadC(string c)
         {
             // Arrange & Act

--- a/CLI.Tests/CLIOptions.cs
+++ b/CLI.Tests/CLIOptions.cs
@@ -297,6 +297,23 @@ namespace Genometric.MSPC.CLI.Tests
         }
 
         [Theory]
+        [InlineData("120%", 2)]
+        [InlineData("300%", 2)]
+        public void MaxCAndShowWarrning(string inputC, int expectedC)
+        {
+            // Arrange
+            var args = new StringBuilder(GenerateShortNameArguments(null, null, null, c: inputC));
+            args.Append(" -i sample_1 -i sample_2");
+
+            // Act
+            var options = new CommandLineOptions();
+            var po = options.Parse(args.ToString().Split(' '), out bool _);
+
+            // Assert
+            Assert.Equal(expectedC, po.C);
+        }
+
+        [Theory]
         [InlineData("lowest", MultipleIntersections.UseLowestPValue)]
         [InlineData("LowEST", MultipleIntersections.UseLowestPValue)]
         [InlineData("highest", MultipleIntersections.UseHighestPValue)]

--- a/CLI.Tests/Main.cs
+++ b/CLI.Tests/Main.cs
@@ -623,5 +623,21 @@ namespace Genometric.MSPC.CLI.Tests
             File.Delete(rep2Path);
             Directory.Delete(path, true);
         }
+
+        [Theory]
+        [InlineData("300%",  "2")]
+        [InlineData("-300%", "1")]
+        public void WarningDisplayedForInvalidC(string c, string expected)
+        {
+            // Arrange
+            string msg;
+
+            // Act
+            using (var tmpMspc = new TmpMspc())
+                msg = tmpMspc.Run(template: $"-i sample_1 -i sample_2 -r bio -w 1E-2 -s 1E-8 -c {c}");
+
+            // Assert
+            Assert.Contains($"Invalid `C={c}`, it is set to `C={expected}`.", msg);
+        }
     }
 }

--- a/CLI/CLI.csproj
+++ b/CLI/CLI.csproj
@@ -52,10 +52,6 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-	<None Include="..\website\static\img\logo.png">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-	</None>
   </ItemGroup>
 
 </Project>

--- a/CLI/CommandLineOptions.cs
+++ b/CLI/CommandLineOptions.cs
@@ -255,6 +255,8 @@ namespace Genometric.MSPC.CLI
 
                 if (_vc < 1)
                     _vc = 1;
+                else if (_vc > _inputFiles.Count)
+                    _vc = _inputFiles.Count;
             }
 
             if (_cM.HasValue())

--- a/CLI/CommandLineOptions.cs
+++ b/CLI/CommandLineOptions.cs
@@ -79,6 +79,8 @@ namespace Genometric.MSPC.CLI
             Description = "Sets a path where analysis results should be persisted."
         };
 
+        public List<string> Warnings { set; get; }
+
         private ReplicateType _vreplicate;
         private double _vtauS = 1E-8;
         private double _vtauW = 1E-4;
@@ -147,6 +149,8 @@ namespace Genometric.MSPC.CLI
             _cla.Options.Add(_cOutput);
             Func<int> assertArguments = AssertArguments;
             _cla.OnExecute(assertArguments);
+
+            Warnings = new List<string>();
         }
 
         private int AssertArguments()
@@ -254,9 +258,15 @@ namespace Genometric.MSPC.CLI
                     throw new ArgumentException("Invalid value given for the `" + _cC.ShortName + "` argument.");
 
                 if (_vc < 1)
+                {
+                    Warnings.Add($"Invalid `C={_cC.Value()}`, it is set to `C=1`.");
                     _vc = 1;
+                }
                 else if (_vc > _inputFiles.Count)
+                {
+                    Warnings.Add($"Invalid `C={_cC.Value()}`, it is set to `C={_inputFiles.Count}`.");
                     _vc = _inputFiles.Count;
+                }
             }
 
             if (_cM.HasValue())

--- a/CLI/Logging/Logger.cs
+++ b/CLI/Logging/Logger.cs
@@ -121,6 +121,19 @@ namespace Genometric.MSPC.CLI.Logging
             Console.WriteLine(_cannotContinue);
         }
 
+        public void LogWarning(string message)
+        {
+            log.Warn(message);
+            LogWarningStatic(message);
+        }
+
+        public static void LogWarningStatic(string message)
+        {
+            Console.ForegroundColor = ConsoleColor.DarkMagenta;
+            Console.WriteLine($"Warning: {message}");
+            Console.ResetColor();
+        }
+
         public void LogMSPCStatus(object sender, ValueEventArgs e)
         {
             var msg = new StringBuilder();

--- a/CLI/Orchestrator.cs
+++ b/CLI/Orchestrator.cs
@@ -92,6 +92,14 @@ namespace Genometric.MSPC.CLI
                 options.Parse(args, out bool helpIsDisplayed);
                 if (helpIsDisplayed)
                     return false;
+                if (options.Warnings.Count > 0)
+                    if (_logger == null)
+                        foreach (var msg in options.Warnings)
+                            Logger.LogWarningStatic(msg);
+                    else
+                        foreach (var msg in options.Warnings)
+                            _logger.LogWarning(msg);
+
                 return true;
             }
             catch (Exception e)


### PR DESCRIPTION
If the user provides `n` samples but sets `c` to a value more than `n`, the algorithm will work correctly however `c>n` is confusing. Therefore, this PR implements the following: 

- Sets `c <= n`; for instance if `2` samples are given but `c=300%`, the value of `c` will be auto-corrected to `c=2` (or `100%`).
- A warning will be displayed for incorrect but auto-corrected `c` values.  