### PR TITLE
Export results to a given output directory and log the absolute path

### DIFF
--- a/CLI.Tests/Main.cs
+++ b/CLI.Tests/Main.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Text.RegularExpressions;
 using Xunit;
 
 namespace Genometric.MSPC.CLI.Tests
@@ -697,14 +698,14 @@ namespace Genometric.MSPC.CLI.Tests
         public void ExportPathIsReportedInLogs()
         {
             // Arrange
-            var output_path = "mspc_test_output_" + new Random().Next(10000, 99999);
+            var outputPath = "mspc_test_output_" + new Random().Next(10000, 99999);
             WriteSampleFiles(out string rep1Filename, out string rep2Filename, out _);
 
             // Act
             string logFile;
             using (var o = new Orchestrator())
             {
-                o.Orchestrate($"-i {rep1Filename} -i {rep2Filename} -r bio -w 1e-2 -s 1e-4 -o {output_path}".Split(' '));
+                o.Orchestrate($"-i {rep1Filename} -i {rep2Filename} -r bio -w 1e-2 -s 1e-4 -o {outputPath}".Split(' '));
                 logFile = o.LogFile;
             }
 
@@ -715,7 +716,12 @@ namespace Genometric.MSPC.CLI.Tests
                     messages.Add(line);
 
             // Assert
-            Assert.True(messages.FindAll(x => x.Contains("INFO \tExport Directory: ")).Count == 1);
+            var outputPathLogMessage = messages.FindAll(x => x.Contains("INFO \tExport Directory: "));
+            Assert.True(outputPathLogMessage.Count == 1);
+
+            var rx = new Regex(".*Export Directory: (.*)");
+            var loggedOutputPath = rx.Match(outputPathLogMessage[0]).Groups[1].Value;
+            Assert.True(Path.IsPathRooted(loggedOutputPath));
         }
     }
 }

--- a/CLI.Tests/Main.cs
+++ b/CLI.Tests/Main.cs
@@ -373,7 +373,7 @@ namespace Genometric.MSPC.CLI.Tests
             o.Dispose();
             foreach (var dir in dirs)
                 Directory.Delete(dir, true);
-            Directory.Delete(dirs[0] + "2", true);
+            Directory.Delete(dirs[0] + "_2", true);
         }
 
         [Fact]

--- a/CLI.Tests/Main.cs
+++ b/CLI.Tests/Main.cs
@@ -354,7 +354,7 @@ namespace Genometric.MSPC.CLI.Tests
             string baseName = @"TT" + new Random().Next().ToString();
             var dirs = new List<string>
             {
-                baseName, baseName + "0", baseName + "1"
+                baseName, baseName + "_0", baseName + "_1"
             };
 
             foreach (var dir in dirs)
@@ -364,10 +364,10 @@ namespace Genometric.MSPC.CLI.Tests
             }
 
             // Act
-            o.Orchestrate(string.Format("-i rep1.bed -i rep2.bed -r bio -w 1E-2 -s 1E-8 -o {0}", dirs[0]).Split(' '));
+            o.Orchestrate($"-i rep1.bed -i rep2.bed -r bio -w 1E-2 -s 1E-8 -o {dirs[0]}".Split(' '));
 
             // Assert
-            Assert.Equal(o.OutputPath, dirs[0] + "2");
+            Assert.Equal(o.OutputPath, dirs[0] + "_2");
 
             // Clean up
             o.Dispose();

--- a/CLI.Tests/Main.cs
+++ b/CLI.Tests/Main.cs
@@ -344,7 +344,7 @@ namespace Genometric.MSPC.CLI.Tests
 
             // Act
             Program.Main($"-i {rep1Filename} -i {rep2Filename} -r bio -w 1E-2 -s 1E-8 -o {output_path + Path.DirectorySeparatorChar}".Split(' '));
-            output_path = output_path + "_0";
+            output_path += "_0";
 
             // Assert
             Assert.True(Directory.Exists(output_path));
@@ -691,6 +691,31 @@ namespace Genometric.MSPC.CLI.Tests
 
             // Assert
             Assert.Contains($"Invalid `C={c}`, it is set to `C={expected}`.", msg);
+        }
+
+        [Fact]
+        public void ExportPathIsReportedInLogs()
+        {
+            // Arrange
+            var output_path = "mspc_test_output_" + new Random().Next(10000, 99999);
+            WriteSampleFiles(out string rep1Filename, out string rep2Filename, out _);
+
+            // Act
+            string logFile;
+            using (var o = new Orchestrator())
+            {
+                o.Orchestrate($"-i {rep1Filename} -i {rep2Filename} -r bio -w 1e-2 -s 1e-4 -o {output_path}".Split(' '));
+                logFile = o.LogFile;
+            }
+
+            string line;
+            var messages = new List<string>();
+            using (var reader = new StreamReader(logFile))
+                while ((line = reader.ReadLine()) != null)
+                    messages.Add(line);
+
+            // Assert
+            Assert.True(messages.FindAll(x => x.Contains("INFO\tExport Directory: ")).Count == 1);
         }
     }
 }

--- a/CLI.Tests/Main.cs
+++ b/CLI.Tests/Main.cs
@@ -715,7 +715,7 @@ namespace Genometric.MSPC.CLI.Tests
                     messages.Add(line);
 
             // Assert
-            Assert.True(messages.FindAll(x => x.Contains("INFO\tExport Directory: ")).Count == 1);
+            Assert.True(messages.FindAll(x => x.Contains("INFO \tExport Directory: ")).Count == 1);
         }
     }
 }

--- a/CLI.Tests/Main.cs
+++ b/CLI.Tests/Main.cs
@@ -334,6 +334,28 @@ namespace Genometric.MSPC.CLI.Tests
         }
 
         [Fact]
+        public void TrailingSlashIsRemovedFromOutputFolder()
+        {
+            // Arrange
+            var output_path = "mspc_test_output_" + new Random().Next(10000, 99999);
+            Directory.CreateDirectory(output_path);
+            File.Create(output_path + Path.DirectorySeparatorChar + "test").Dispose();
+            WriteSampleFiles(out string rep1Filename, out string rep2Filename, out _);
+
+            // Act
+            Program.Main($"-i {rep1Filename} -i {rep2Filename} -r bio -w 1E-2 -s 1E-8 -o {output_path + Path.DirectorySeparatorChar}".Split(' '));
+
+            // Assert
+            Assert.True(Directory.Exists(output_path + "_0"));
+            // There should be three files in the output directory:
+            // Log file; Consensus peaks in BED and MSPC format.
+            Assert.Equal(3, Directory.GetFiles(output_path).Length);
+            // There should be two folders in the output directory 
+            // one per each input replicate.
+            Assert.Equal(2, Directory.GetDirectories(output_path).Length);
+        }
+
+        [Fact]
         public void GenerateOutputPathIfNotGiven()
         {
             // Arrange

--- a/CLI.Tests/Main.cs
+++ b/CLI.Tests/Main.cs
@@ -344,9 +344,10 @@ namespace Genometric.MSPC.CLI.Tests
 
             // Act
             Program.Main($"-i {rep1Filename} -i {rep2Filename} -r bio -w 1E-2 -s 1E-8 -o {output_path + Path.DirectorySeparatorChar}".Split(' '));
+            output_path = output_path + "_0";
 
             // Assert
-            Assert.True(Directory.Exists(output_path + "_0"));
+            Assert.True(Directory.Exists(output_path));
             // There should be three files in the output directory:
             // Log file; Consensus peaks in BED and MSPC format.
             Assert.Equal(3, Directory.GetFiles(output_path).Length);

--- a/CLI/CommandLineOptions.cs
+++ b/CLI/CommandLineOptions.cs
@@ -287,7 +287,7 @@ namespace Genometric.MSPC.CLI
             if (_cOutput.HasValue())
                 OutputPath = _cOutput.Value();
 
-            if(_cDP.HasValue())
+            if (_cDP.HasValue())
             {
                 if (int.TryParse(_cDP.Value(), out int dp))
                     DegreeOfParallelism = dp;

--- a/CLI/Logging/Logger.cs
+++ b/CLI/Logging/Logger.cs
@@ -47,12 +47,12 @@ namespace Genometric.MSPC.CLI.Logging
             }
         }
 
-        public Logger(string logFilePath, string repository, string name)
+        public Logger(string logFilePath, string repository, string name, string exportPath)
         {
-            Setup(logFilePath, repository, name);
+            Setup(logFilePath, repository, name, exportPath);
         }
 
-        private void Setup(string logFilePath, string repository, string name)
+        private void Setup(string logFilePath, string repository, string name, string exportPath)
         {
             _repository = repository;
             _name = name;
@@ -85,6 +85,7 @@ namespace Genometric.MSPC.CLI.Logging
             log = LogManager.GetLogger(_repository, _name);
 
             log.Info("NOTE THAT THE LOG PATTERN IS: <Date> <#Thread> <Level> <Message>");
+            log.Info($"Export Directory: {exportPath}");
         }
 
         public void LogStartOfASection(string header)

--- a/CLI/Orchestrator.cs
+++ b/CLI/Orchestrator.cs
@@ -128,7 +128,7 @@ namespace Genometric.MSPC.CLI
                     if (Directory.GetFiles(OutputPath).Any())
                     {
                         int c = 0;
-                        do OutputPath = path + c++;
+                        do OutputPath = $"{path}_{c++}";
                         while (Directory.Exists(OutputPath));
                         Directory.CreateDirectory(OutputPath);
                     }

--- a/CLI/Orchestrator.cs
+++ b/CLI/Orchestrator.cs
@@ -162,7 +162,7 @@ namespace Genometric.MSPC.CLI
 
                 var repository = _defaultLoggerRepoName + "_" + DateTime.Now.ToString(loggerTimeStampFormat, CultureInfo.InvariantCulture);
                 LogFile = OutputPath + Path.DirectorySeparatorChar + repository + ".txt";
-                _logger = new Logger(LogFile, repository, Guid.NewGuid().ToString());
+                _logger = new Logger(LogFile, repository, Guid.NewGuid().ToString(), OutputPath);
                 return true;
             }
             catch (Exception e)

--- a/CLI/Orchestrator.cs
+++ b/CLI/Orchestrator.cs
@@ -119,6 +119,8 @@ namespace Genometric.MSPC.CLI
                 path =
                     Environment.CurrentDirectory + Path.DirectorySeparatorChar +
                     "session_" + DateTime.Now.ToString("yyyyMMdd_HHmmssfff", CultureInfo.InvariantCulture);
+            else
+                path = path.TrimEnd(Path.DirectorySeparatorChar);
 
             OutputPath = path;
             try

--- a/CLI/Orchestrator.cs
+++ b/CLI/Orchestrator.cs
@@ -122,7 +122,7 @@ namespace Genometric.MSPC.CLI
             else
                 path = path.TrimEnd(Path.DirectorySeparatorChar);
 
-            OutputPath = path;
+            OutputPath = Path.GetFullPath(path);
             try
             {
                 if (Directory.Exists(OutputPath))

--- a/website/docs/cli/args.md
+++ b/website/docs/cli/args.md
@@ -240,6 +240,11 @@ using a JSON object.
 ### Output Path
 
 Sets the path in which analysis results should be persisted.
+If it is not given, the default folder is name `session_` + `<Timestamp>`.
+If a given folder name already exists, and is not empty, MSPC 
+will append `_n` where `n` is an integer until no duplicate is 
+found. See the [Output](output) page on the contents of 
+this folder.
 
 | Short | Long | Required | Valid values | Default value |
 | ----- | ---- | ---- | ------------ | ------------- |

--- a/website/docs/cli/output.md
+++ b/website/docs/cli/output.md
@@ -6,7 +6,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 MSPC persists the results of each execution to a separate folder. Users can specify 
-the output directory via the optional argument [`-o | --output`](cli/args#output-path); 
+the output directory via the optional argument [`-o | --output`](../cli/args#output-path); 
 if not specified, MSPC creates an output directory with the following naming scheme. 
 
 ```

--- a/website/docs/cli/output.md
+++ b/website/docs/cli/output.md
@@ -1,38 +1,235 @@
----
+﻿---
 title: Output
 ---
 
-import useBaseUrl from '@docusaurus/useBaseUrl';
-import ThemedImage from '@theme/ThemedImage';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-MSPC outputs each classifications of peaks (e.g., `stringent`, `weak`, `confirmed`, or
-`discarded`) in separate BED files. See the following figure for different sets and their 
-relation. 
+MSPC persists the results of each execution to a separate folder. Users can specify 
+the output directory via the optional argument [`-o | --output`](cli/args#output-path); 
+if not specified, MSPC creates an output directory with the following naming scheme. 
 
-<ThemedImage
-  alt="Sets"
-  sources={{
-    light: useBaseUrl('/img/sets.svg'),
-    dark: useBaseUrl('/img/sets_dark.svg'),
-  }}
-/>
-
-See [Sets](method/sets.md) page for description of each category.
-
-
-Each peak in an output BED file is represented by its parsed information (i.e., `chr`, `chromStart`, 
-`chromEnd`, `name`, and `p-value`) and its comparative analysis values (e.g., combined significance,
-and its right-tail probability). For instance:
-
-```shell
-# Input:
-chr   chromStart   chromEnd    name     p-value
-chr1  32600        32680       peak_1   4.08
-
-# Output (e.g., Confirmed.bed):
-chr   chromStart   chromEnd    name     p-value    xSquared     right-tail_probability
-chr1  32600        32680       peak_1   4.08       222.936      46.373
 ```
+session_[DATE]_[TIME]
+
+// For example:
+session_20191126_222131330
+```
+
+Each output folder contains the following information: 
+
+A log file that contains the execution log;
+Consensus peaks in standard BED and MSPC format;
+One folder per each replicates contains BED files containing 
+[`stringent`](../method/sets#stringent), [`weak`](../method/sets#weak), 
+[`background`](../method/sets#background), [`confirmed`](../method/sets#confirmed), 
+[`discarded`](../method/sets#discarded), [`true-positive`](../method/sets#truepositive), 
+and [`false-positive`](../method/sets#falsepositive) peaks. 
+You may refer to the [Sets](../method/sets.md) page for a detailed 
+description of each category.
+
+An MSPC generated output for two replicates `rep1` and `rep2` is as the following: 
+
+```
+.
+└── session_20210309_131747501
+    ├── ConsensusPeaks.bed
+	├── ConsensusPeaks_mspc_peaks.txt
+	├── EventsLog_20210309_1317475050929.txt
+    ├── rep1
+    │   ├── Background.bed
+    │   ├── Background_mspc_peaks.txt
+    │   ├── Confirmed.bed
+    │   ├── Confirmed_mspc_peaks.txt
+    │   ├── Discarded.bed
+    │   ├── Discarded_mspc_peaks.txt
+    │   ├── FalsePositive.bed
+    │   ├── FalsePositive_mspc_peaks.txt
+    │   ├── Stringent.bed
+    │   ├── Stringent_mspc_peaks.txt
+    │   ├── TruePositive.bed
+    │   ├── TruePositive_mspc_peaks.txt
+    │   └── Weak.bed
+    │   ├── Weak_mspc_peaks.txt
+    └── rep2
+        ├── Background.bed
+        ├── Background_mspc_peaks.txt
+        ├── Confirmed.bed
+        ├── Confirmed_mspc_peaks.txt
+        ├── Discarded.bed
+        ├── Discarded_mspc_peaks.txt
+        ├── FalsePositive.bed
+        ├── FalsePositive_mspc_peaks.txt
+        ├── Stringent.bed
+        ├── Stringent_mspc_peaks.txt
+        ├── TruePositive.bed
+        ├── TruePositive_mspc_peaks.txt
+        └── Weak.bed
+        └── Weak_mspc_peaks.txt
+```
+
+## BED files
+
+The `*.bed` files contain peaks in the standard 
+[BED format](https://genome.ucsc.edu/FAQ/FAQformat.html#format1). 
+These files contain peaks parsed from input files organized under 
+the `stringent`, `weak`, `background`, `confirmed`, `discarded`, 
+`true-positive` and `false-positive` groups. For example, peaks 
+in a `Confirmed.bed` and `Discarded.bed` files may read is the following: 
+
+```
+$ head .\rep1\Confirmed.bed
+chr     start   stop    name    -1xlog10(p-value)
+chr1    32600   32680   MACS_peak_4     4.08
+chr1    32726   32936   MACS_peak_5     17.5
+chr1    34689   34797   MACS_peak_6     5.82
+chr1    35083   35124   MACS_peak_7     4.59
+chr1    38593   38836   MACS_peak_8     10.7
+
+$ head .\rep1\Discarded.bed
+chr     start   stop    name    -1xlog10(p-value)
+chr1    137343  137383  MACS_peak_10    4.8
+chr1    228585  228625  MACS_peak_12    4.37
+chr1    265059  265115  MACS_peak_14    5.22
+chr1    557793  557833  MACS_peak_29    4.16
+chr1    725914  725963  MACS_peak_34    5.95
+``` 
+
+Accordingly, the peak named `MACS_peak_4 ` is _confirmed_ while 
+a peak with `MACS_peak_10 ` name is _discarded_. 
+
+## MSPC Peaks
+
+The `*_mspc_peaks.txt` files group input peaks in different 
+groups similar to the `*.bed` files. In addition, they 
+contain information about the analysis performed on each peak. 
+The additional information are: 
+
+1. Combined probability of 
+each peak that is X-squared of 
+[Fisher’s method](https://en.wikipedia.org/wiki/Fisher%27s_method); 
+
+2. Right-tailed probability of the X-squared 
+(represented in `-Log10 (right-tailed probability)`; 
+
+3. Benjamini–Hochberg corrected p-value (represented in 
+`-Log10 (Adjusted p-value)`. 
+
+For example, peaks corresponding to the above-mentioned 
+peaks in the confirmed and discarded sets are as the following.
+
+```
+$ head .\rep1\Confirmed_mspc_peaks.txt
+chr     start   stop    name    -1xlog10(p-value)       xSqrd   -1xlog10(Right-Tail Probability)        -1xlog10(AdjustedP-value)
+chr1    32600   32680   MACS_peak_4     4.08    222.936 46.359  4.07
+chr1    32726   32936   MACS_peak_5     17.5    284.738 59.674  16.146
+chr1    34689   34797   MACS_peak_6     5.82    74.005  14.49   5.634
+chr1    35083   35124   MACS_peak_7     4.59    52.867  10.042  4.537
+chr1    38593   38836   MACS_peak_8     10.7    121.576 24.609  9.892
+
+$ head .\rep1\Discarded_mspc_peaks.txt
+chr     start   stop    name    -1xlog10(p-value)       xSqrd   -1xlog10(Right-Tail Probability)        -1xlog10(AdjustedP-value)
+chr1    137343  137383  MACS_peak_10    4.8     22.105  4.8     NaN
+chr1    228585  228625  MACS_peak_12    4.37    20.125  4.37    NaN
+chr1    265059  265115  MACS_peak_14    5.22    24.039  5.22    NaN
+chr1    557793  557833  MACS_peak_29    4.16    19.158  4.16    NaN
+chr1    725914  725963  MACS_peak_34    5.95    27.401  5.95    NaN
+```
+
+Note that the first five columns are identical between `*.bed` 
+and `*_mspc_peaks.txt` files, the columns 6, 7, and 8 are 
+added in the `*_mspc_peaks.txt` files. 
+
+In order to reproduce these results, you may run the following commands:
+
+<Tabs
+ groupId="operating-systems"
+ defaultValue="win"
+ values={[
+  { label: 'Windows', value: 'win', },
+  { label: 'Linux', value: 'linux', },
+  { label: 'macOS', value: 'mac', },
+ ]
+}>
+ <TabItem value="win">
+
+ ```shell
+ wget -O demo.zip https://github.com/Genometric/Annotations/raw/master/SampleFiles/demo.zip; unzip demo.zip -d .
+ .\mspc.exe -i .\rep*.bed -r bio -w 1e-4 -s 1e-8
+ ```
+
+ </TabItem>
+ <TabItem value="linux">
+
+ ```shell
+ wget -O demo.zip https://github.com/Genometric/Annotations/raw/master/SampleFiles/demo.zip && unzip demo.zip -d .
+ ./mspc -i rep*.bed -r bio -w 1e-4 -s 1e-8
+ ```
+
+ </TabItem>
+ <TabItem value="mac">
+
+ ```shell
+ wget -O demo.zip https://github.com/Genometric/Annotations/raw/master/SampleFiles/demo.zip && unzip demo.zip -d .
+ ./mspc -i rep*.bed -r bio -w 1e-4 -s 1e-8
+ ```
+
+ </TabItem>
+</Tabs>
+
+
+
+
+## Log File
+
+This file contains the information, debugging messages, 
+and exceptions that occurred during the execution. 
+The files reads as the following: 
+
+```
+2021-03-09 15:47:22,524	[1]	INFO 	NOTE THAT THE LOG PATTERN IS: <Date> <#Thread> <Level> <Message>
+2021-03-09 15:47:22,570	[1]	INFO 	Export Directory: C:\mspc\session_20210309_154722332
+2021-03-09 15:47:22,572	[1]	INFO 	Degree of parallelism is set to 8.
+2021-03-09 15:47:22,595	[1]	INFO 	.::...Parsing Samples....::.
+2021-03-09 15:47:22,597	[1]	INFO 	   #	            Filename	Read peaks#	Min p-value	Mean p-value	Max p-value	
+2021-03-09 15:47:22,597	[1]	INFO 	----	--------------------	-----------	-----------	------------	-----------	
+2021-03-09 15:47:22,906	[1]	INFO 	1/2	.\rep1.bed	53,697	2.239E-074	1.085E-003	1.000E-002	
+2021-03-09 15:47:23,082	[1]	INFO 	2/2	.\rep2.bed	37,717	5.370E-301	1.520E-004	9.550E-003	
+2021-03-09 15:47:23,084	[1]	INFO 	.::..Analyzing Samples...::.
+2021-03-09 15:47:23,093	[5]	INFO 	[1/4] Initializing
+2021-03-09 15:47:23,412	[5]	INFO 	[2/4] Processing samples
+...
+2021-03-09 15:47:23,749	[1]	INFO 	.::....Saving Results....::.
+2021-03-09 15:47:26,162	[1]	INFO 	.::..Summary Statistics..::.
+2021-03-09 15:47:26,163	[1]	INFO 	   #	            Filename	Read peaks#	Background	    Weak	Stringent	Confirmed	Discarded	TruePositive	FalsePositive	
+2021-03-09 15:47:26,164	[1]	INFO 	----	--------------------	-----------	----------	--------	---------	---------	---------	------------	-------------	
+2021-03-09 15:47:26,178	[1]	INFO 	 1/2	                rep1	     53,697	    47.05%	  42.95%	   10.01%	   26.84%	   26.12%	      26.84%	        0.00%	
+2021-03-09 15:47:26,191	[1]	INFO 	 2/2	                rep2	     37,717	    16.30%	  50.35%	   33.35%	   43.48%	   40.22%	      43.48%	        0.00%	
+2021-03-09 15:47:26,192	[1]	INFO 	.::.Consensus Peaks Count.::.
+2021-03-09 15:47:26,192	[1]	INFO 	17,290
+2021-03-09 15:47:26,193	[1]	INFO 	Elapsed time: 00:00:03.9396445
+2021-03-09 15:47:26,193	[1]	INFO 	All processes successfully finished.
+
+```
+
+Note that the logs are reported in the following format: 
+
+```
+<Date> <#Thread> <Level> <Message>
+```
+
+- `Message` is the description of each log entry;
+
+- Possible values for `Level` are `INFO`, `DEBUG` and `ERR`;
+
+- `Thread` is the number of the process thread MSPC used for 
+executing each process. MSPC runs operations in parallel 
+using `n` threads, where `n` is the degree of parallelism 
+and reported at the beginning of the logs. It can be set 
+via the [`-d | -degree-of-parallelism argument`](../cli/args#degree-of-parallelism). 
+This information is useful for debugging purposes only. 
+
+
 
 ## See Also
 

--- a/website/docs/quick_start.md
+++ b/website/docs/quick_start.md
@@ -151,7 +151,9 @@ To run MSPC use the following command depending on your runtime:
 
 ## Output
 
-MSPC creates a folder in the current execution path named `session_X_Y`, where `X` and `Y` are execution date and time respectively, which contains the following files and folders:
+MSPC creates a folder in the current execution path named `session_X_Y`, 
+where `X` and `Y` are execution date and time respectively, which contains 
+the following files and folders:
 
 ```bash
 .


### PR DESCRIPTION
- [x] Ensure results are written to a given output path;
- [x] If a given output path exists, append a number instead of creating subdirectories (bug fix);
- [x] Report the absolute export path in the log file;
- [x] Update documentation.      