### PR TITLE
Report the export path on console

### DIFF
--- a/CLI/Logging/Logger.cs
+++ b/CLI/Logging/Logger.cs
@@ -85,7 +85,16 @@ namespace Genometric.MSPC.CLI.Logging
             log = LogManager.GetLogger(_repository, _name);
 
             log.Info("NOTE THAT THE LOG PATTERN IS: <Date> <#Thread> <Level> <Message>");
-            log.Info($"Export Directory: {exportPath}");
+            LogExportPath(exportPath);
+        }
+
+        private void LogExportPath(string exportPath)
+        {
+            string msg = $"Export Directory: {exportPath}";
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.WriteLine(Environment.NewLine + msg);
+            Console.ResetColor();
+            log.Info(msg);
         }
 
         public void LogStartOfASection(string header)

--- a/CLI/Logging/Logger.cs
+++ b/CLI/Logging/Logger.cs
@@ -85,25 +85,13 @@ namespace Genometric.MSPC.CLI.Logging
             log = LogManager.GetLogger(_repository, _name);
 
             log.Info("NOTE THAT THE LOG PATTERN IS: <Date> <#Thread> <Level> <Message>");
-            LogExportPath(exportPath);
-        }
-
-        private void LogExportPath(string exportPath)
-        {
-            string msg = $"Export Directory: {exportPath}";
-            Console.ForegroundColor = ConsoleColor.DarkGray;
-            Console.WriteLine(Environment.NewLine + msg);
-            Console.ResetColor();
-            log.Info(msg);
+            Log($"Export Directory: {exportPath}", ConsoleColor.DarkGray);
         }
 
         public void LogStartOfASection(string header)
         {
             string msg = ".::." + header.PadLeft(((_sectionHeaderLenght - header.Length) / 2) + header.Length, '.').PadRight(_sectionHeaderLenght, '.') + ".::.";
-            Console.ForegroundColor = ConsoleColor.Yellow;
-            Console.WriteLine(Environment.NewLine + msg);
-            Console.ResetColor();
-            log.Info(msg);
+            Log(Environment.NewLine + msg, ConsoleColor.Yellow);
         }
 
         public void LogException(Exception e)
@@ -179,9 +167,12 @@ namespace Genometric.MSPC.CLI.Logging
             }
         }
 
-        public void Log(string message)
+        public void Log(string message, ConsoleColor color = ConsoleColor.Black)
         {
+            if (color != ConsoleColor.Black)
+                Console.ForegroundColor = color;
             Console.WriteLine(message);
+            Console.ResetColor();
             log.Info(message);
         }
 

--- a/CLI/Orchestrator.cs
+++ b/CLI/Orchestrator.cs
@@ -203,7 +203,7 @@ namespace Genometric.MSPC.CLI
             if (dp > 0)
                 _degreeOfParallelism = dp;
 
-            _logger.Log(string.Format("Degree of parallelism is set to {0}.", _degreeOfParallelism));
+            _logger.Log(string.Format("Degree of parallelism is set to {0}.", _degreeOfParallelism), ConsoleColor.DarkGray);
         }
 
         private bool LoadParserConfig(CommandLineOptions options, out ParserConfig config)


### PR DESCRIPTION
The export path is reported as the following on the console: 

```
.\mspc.exe -i .\rep*.bed -r bio -w 1e-4 -s 1e-8
Export Directory: C:\mspc\session_20210314_212356641
Degree of parallelism is set to 8.

.::...Parsing Samples....::.
   #                Filename    Read peaks#     Min p-value     Mean p-value    Max p-value
----    --------------------    -----------     -----------     ------------    -----------
 1/2                    rep1         53,697      2.239E-074       1.085E-003     1.000E-002
 2/2                    rep2         37,717      5.370E-301       1.520E-004     9.550E-003

.::..Analyzing Samples...::.
...
```