### PR TITLE
Improvements to the benchmarking scripts

### DIFF
--- a/Benchmark/PerformanceTest.cs
+++ b/Benchmark/PerformanceTest.cs
@@ -29,12 +29,12 @@ namespace Genometric.MSPC.Benchmark
                 var msg = $"\t[{++counter}/{cases.Count}]\tBenchmarking using {c.Key}: ... ";
                 Console.Write(msg);
                 var reps = SyntheticReps.Generate(c.Value, maxRepCount);
+                var syntheticReps = reps.Except(c.Value).ToList();
 
                 var minRepCount = 2;
                 for (int i = minRepCount; i <= maxRepCount; i++)
                 {
                     var testReps = reps.Take(i).ToList();
-
                     verInfo.InputFiles = testReps;
                     var result = MeasurePerformance(verInfo.StartInfo);
                     result.Version = verInfo.Version;
@@ -48,6 +48,8 @@ namespace Genometric.MSPC.Benchmark
                     Console.Write($"\r{msg}{Math.Floor((i - minRepCount) / (double)(maxRepCount - minRepCount) * 100)}%");
                 }
 
+                foreach (var syntheticRep in syntheticReps)
+                    File.Delete(syntheticRep);
                 timer.Stop();
                 Console.WriteLine($"\r{msg}Done!\t(ET: {timer.Elapsed}");
 
@@ -58,7 +60,7 @@ namespace Genometric.MSPC.Benchmark
             }
         }
 
-        private static Result MeasurePerformance(ProcessStartInfo info, int waitMilliseconds = 100)
+        private static Result MeasurePerformance(ProcessStartInfo info, int waitToExitInMilliseconds = 100)
         {
             var result = new Result();
 
@@ -93,7 +95,7 @@ namespace Genometric.MSPC.Benchmark
                         process.StandardOutput.ReadToEnd();
                     }
                 }
-                while (!process.WaitForExit(waitMilliseconds));
+                while (!process.WaitForExit(waitToExitInMilliseconds));
                 result.Runtime.Stop();
             }
 

--- a/Benchmark/PerformanceTest.cs
+++ b/Benchmark/PerformanceTest.cs
@@ -50,6 +50,8 @@ namespace Genometric.MSPC.Benchmark
 
                 foreach (var syntheticRep in syntheticReps)
                     File.Delete(syntheticRep);
+                if (verInfo.OutputDir != null)
+                    Directory.Delete(verInfo.OutputDir, true);
                 timer.Stop();
                 Console.WriteLine($"\r{msg}Done!\t(ET: {timer.Elapsed}");
 

--- a/Benchmark/PerformanceTest.cs
+++ b/Benchmark/PerformanceTest.cs
@@ -38,6 +38,7 @@ namespace Genometric.MSPC.Benchmark
                     verInfo.InputFiles = testReps;
                     var result = MeasurePerformance(verInfo.StartInfo);
                     result.Version = verInfo.Version;
+                    result.ExperimentId = c.Key;
                     result.ReplicateCount = testReps.Count;
                     foreach (var filename in testReps)
                         result.IntervalCount += GetPeaksCount(filename);

--- a/Benchmark/Result.cs
+++ b/Benchmark/Result.cs
@@ -8,6 +8,8 @@ namespace Genometric.MSPC.Benchmark
 
         public string Version { set; get; } = "not_specified";
 
+        public string ExperimentId { set; get; } = "not_specified";
+
         public int ReplicateCount { set; get; }
 
         public int IntervalCount { set; get; }
@@ -35,6 +37,7 @@ namespace Genometric.MSPC.Benchmark
             return string.Join(delimiter, new string[]
             {
                 "mspc_version",
+                "experiment_id",
                 "replicate_count",
                 "interval_count",
                 "runtime_seconds",
@@ -49,6 +52,7 @@ namespace Genometric.MSPC.Benchmark
             return string.Join(delimiter, new string[]
             {
                 Version,
+                ExperimentId,
                 ReplicateCount.ToString(),
                 IntervalCount.ToString(),
                 Runtime.Elapsed.TotalSeconds.ToString(),

--- a/Benchmark/SyntheticReps.cs
+++ b/Benchmark/SyntheticReps.cs
@@ -13,7 +13,7 @@
             {
                 extReps.Add(RandomAlter(
                     filename: replicates[i],
-                    filenamePostfix: "_rnd_" + (extReps.Count + 1).ToString(),
+                    filenamePostfix: "_synthetic_" + (extReps.Count + 1).ToString(),
                     rndSeed: (extReps.Count * 10) + replicates[i].Length));
 
                 if (++i >= replicates.Count)

--- a/Benchmark/SyntheticReps.cs
+++ b/Benchmark/SyntheticReps.cs
@@ -20,7 +20,7 @@
                     i = 0;
             }
 
-            return replicates;
+            return extReps;
         }
 
         public static string RandomAlter(string filename, string filenamePostfix, int rndSeed = 0)

--- a/Benchmark/VersionInfo.cs
+++ b/Benchmark/VersionInfo.cs
@@ -26,6 +26,8 @@ namespace Genometric.MSPC.Benchmark
 
         public Uri ReleaseUri { private set; get; }
 
+        public string? OutputDir { private set; get; } = null;
+
 
         public VersionInfo(
             string version,
@@ -49,11 +51,12 @@ namespace Genometric.MSPC.Benchmark
             {
                 _invocation = "mspc.exe";
                 ReleaseUri = new Uri(ReleaseUri, $"download/{version}/mspc.zip");
+                SetOutputDir();
                 return true;
             }
 
             pattern = new Regex(@"^v2\.\d+(\.\d+)?$");
-            if(pattern.IsMatch(version))
+            if (pattern.IsMatch(version))
             {
                 _invocation = "mspc.exe";
                 ReleaseUri = new Uri(ReleaseUri, $"download/{version}/v2.1.zip");
@@ -82,6 +85,13 @@ namespace Genometric.MSPC.Benchmark
             ZipFile.ExtractToDirectory(filename, dir);
 
             return (true, dir);
+        }
+
+        private void SetOutputDir()
+        {
+            OutputDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(OutputDir);
+            Args += $" -o {Path.Combine(OutputDir, "tmp")}";
         }
     }
 }


### PR DESCRIPTION
- [x] Provide the experiment ID  in the benchmarking report;
- [x] Delete created synthetic replicates;
- [x] Delete the mspc output created during the benchmarking;
- [x] Bug fix returning the list of input and synthetic reps.