### PR TITLE
Improvements to the benchmarking script

### DIFF
--- a/Benchmark/Program.cs
+++ b/Benchmark/Program.cs
@@ -12,6 +12,9 @@ namespace Genometric.MSPC.Benchmark
 
         public static async Task Handler(string[] releases, DirectoryInfo dataDir, int maxRepCount)
         {
+            if (!dataDir.Exists)
+                throw new DirectoryNotFoundException($"{dataDir.FullName} does not exist.");
+
             var resultsFilename = Path.Join(
                 dataDir.FullName,
                 $"mspc_versions_benchmarking_results_" +

--- a/Benchmark/VersionInfo.cs
+++ b/Benchmark/VersionInfo.cs
@@ -80,7 +80,7 @@ namespace Genometric.MSPC.Benchmark
 
         private async Task<(bool, string)> TryLocalize()
         {
-            var dir = Path.Join(Path.GetTempPath(), "mspc", Version.ToLower().Replace(".", "_"));
+            var dir = Path.Combine(Environment.CurrentDirectory, "mspc", Version.ToLower().Replace(".", "_"));
             if (Directory.Exists(dir))
                 return (true, dir);
                 


### PR DESCRIPTION
- [x] Fix a bug localizing an MSPC version on Mac where the default temp dir dotnet uses may not be accessible by the user running the application. Using `sudo` may not also fix it. Hence, switch to using the current execution dir instead of the system/user temp dir. 
- [x] Improve on calling parser and handling exceptions; with this change, errors are handled by the provided delegate rather than the default delegate of CLI (which also prints the stack trace that is not useful to the end-user);
- [x] Check if the given data directory exists before proceeding. 