### PR TITLE
Improve portability of benchmarking script

### DIFF
--- a/Benchmark/Program.cs
+++ b/Benchmark/Program.cs
@@ -5,13 +5,7 @@ namespace Genometric.MSPC.Benchmark
     static class Program
     {
         public static async Task<int> Main(string[] args)
-        {
-            if(!OperatingSystem.IsWindows())
-            {
-                Console.Error.WriteLine("Running benchmarks is currently supported on Windows only.");
-                return 1;
-            }
-            
+        {            
             var cli = new CommandLineInterface(Handler);
             return await cli.InvokeAsync(args);
         }


### PR DESCRIPTION
Invoke MSPC in the benchmarking script in a cross-platform way; i.e., `dotnet mspc.dll`. 

The only caveat is that this type of invocation is supported on the latest versions; mainly since `v4`. Earlier versions need further testing, but some versions are not expected to support since they are not cross-platform; `v1` in particular.   