### PR TITLE
Set the default max degree of parallelism to the max allowed by the underlying scheduler

### DIFF
--- a/CLI/Orchestrator.cs
+++ b/CLI/Orchestrator.cs
@@ -196,10 +196,9 @@ namespace Genometric.MSPC.CLI
             try
             {
                 _logger.LogStartOfASection("Analyzing Samples");
-                mspc = new Mspc()
-                {
-                    DegreeOfParallelism = options.DegreeOfParallelism ?? Environment.ProcessorCount
-                };
+                mspc = new Mspc(
+                    maxDegreeOfParallelism: options.DegreeOfParallelism);
+
                 mspc.StatusChanged += _logger.LogMSPCStatus;
                 foreach (var sample in samples)
                     mspc.AddSample(sample.FileHashKey, sample);

--- a/Core.Tests/Concurrency/Concurrency.cs
+++ b/Core.Tests/Concurrency/Concurrency.cs
@@ -54,10 +54,9 @@ namespace Genometric.MSPC.Core.Tests.Concurrency
         public void HighDegreeOfParallelisim()
         {
             // Arrange
-            var mspc = new Mspc();
+            var mspc = new Mspc(maxDegreeOfParallelism: 20);
             mspc.AddSample(0, CreateSample(0, 20, 10000));
             mspc.AddSample(1, CreateSample(2, 20, 20000));
-            mspc.DegreeOfParallelism = 20;
 
             // Act
             var res = mspc.Run(new Config(

--- a/Core.Tests/PublicMembers.cs
+++ b/Core.Tests/PublicMembers.cs
@@ -218,10 +218,7 @@ namespace Genometric.MSPC.Core.Tests
         {
             // Arrange && Act
             int dp = 123;
-            var mspc = new Mspc()
-            {
-                DegreeOfParallelism = dp
-            };
+            var mspc = new Mspc(maxDegreeOfParallelism: dp);
 
             // Assert
             Assert.Equal(mspc.DegreeOfParallelism, dp);

--- a/Core/Functions/FalseDiscoveryRate.cs
+++ b/Core/Functions/FalseDiscoveryRate.cs
@@ -18,11 +18,15 @@ namespace Genometric.MSPC.Core.Functions
         /// <summary>
         /// Benjamini–Hochberg (step-up) procedure.
         /// </summary>
-        public void PerformMultipleTestingCorrection(Dictionary<uint, Result<I>> results, float alpha, int degreeOfParallelism)
+        public void PerformMultipleTestingCorrection(Dictionary<uint, Result<I>> results, float alpha, int? degreeOfParallelism)
         {
+            var options = new ParallelOptions();
+            if (degreeOfParallelism is not null)
+                options.MaxDegreeOfParallelism = (int)degreeOfParallelism;
+
             Parallel.ForEach(
                 results,
-                new ParallelOptions { MaxDegreeOfParallelism = degreeOfParallelism },
+                options,
                 result =>
                 {
                     PerformMultipleTestingCorrection(UnionChrs(result.Value.Chromosomes), alpha);

--- a/Core/Mspc.cs
+++ b/Core/Mspc.cs
@@ -8,7 +8,13 @@ namespace Genometric.MSPC.Core
 {
     public class Mspc : Mspc<Peak>
     {
-        public Mspc(bool trackSupportingRegions = false) : base(new PeakConstructor(), trackSupportingRegions)
+        public Mspc(
+            bool trackSupportingRegions = false,
+            int? maxDegreeOfParallelism = null) :
+            base(
+                new PeakConstructor(),
+                trackSupportingRegions,
+                maxDegreeOfParallelism: maxDegreeOfParallelism)
         { }
     }
 }

--- a/Core/MspcGeneric.cs
+++ b/Core/MspcGeneric.cs
@@ -31,15 +31,21 @@ namespace Genometric.MSPC.Core
 
         private ReadOnlyDictionary<uint, Result<I>> _results { set; get; }
 
-        public int DegreeOfParallelism
+        public int? DegreeOfParallelism
         {
-            set { _processor.DegreeOfParallelism = value; }
             get { return _processor.DegreeOfParallelism; }
         }
 
-        public Mspc(IPeakConstructor<I> peakConstructor, bool trackSupportingRegions = false)
+        public Mspc(
+            IPeakConstructor<I> peakConstructor,
+            bool trackSupportingRegions = false,
+            int? maxDegreeOfParallelism = null)
         {
-            _processor = new Processor<I>(peakConstructor, trackSupportingRegions);
+            _processor = new Processor<I>(
+                peakConstructor,
+                trackSupportingRegions,
+                maxDegreeOfParallelism);
+
             _processor.OnProgressUpdate += _processorOnProgressUpdate;
             _backgroundProcessor = new BackgroundWorker();
             _backgroundProcessor.DoWork += _doWork;


### PR DESCRIPTION
This improves performance as it allows mspc to utilize as many threads as the underlying scheduler provides, hence can better leverage the available system resources. 