### PR TITLE
Make the analysis stranded

### DIFF
--- a/CLI.Tests/Exporter.cs
+++ b/CLI.Tests/Exporter.cs
@@ -47,8 +47,8 @@ namespace Genometric.MSPC.CLI.Tests
         private string Header(bool mspcFormat)
         {
             return mspcFormat ?
-                "chr\tstart\tstop\tname\t-1xlog10(p-value)\txSqrd\t-1xlog10(Right-Tail Probability)\t-1xlog10(AdjustedP-value)" :
-                "chr\tstart\tstop\tname\t-1xlog10(p-value)";
+                "chr\tstart\tstop\tname\t-1xlog10(p-value)\tstrand\txSqrd\t-1xlog10(Right-Tail Probability)\t-1xlog10(AdjustedP-value)" :
+                "chr\tstart\tstop\tname\t-1xlog10(p-value)\tstrand";
         }
 
         private string RunMSPCAndExportResultsWithMultiChr()
@@ -313,14 +313,14 @@ namespace Genometric.MSPC.CLI.Tests
         }
 
         [Theory]
-        [InlineData(0, Attributes.Background, "chr1", 3, 13, "r11", 2, double.NaN, double.NaN, double.NaN)]
+        [InlineData(0, Attributes.Background, "chr1", 3, 13, "r11", 2, '.', double.NaN, double.NaN, double.NaN)]
         public void CorrectValuesForEachPropertyOfExportedPeakInMSPCPeakFile(
             uint sampleID, Attributes attribute,
-            string chr, int left, int right, string name, double value, double xSqrd, double rtp, double adjustedPValue)
+            string chr, int left, int right, string name, double value, char strand, double xSqrd, double rtp, double adjustedPValue)
         {
             // Arrange
             string path = RunMSPCAndExportResults();
-            string expectedLine = chr + "\t" + left + "\t" + right + "\t" + name + "\t" + value + "\t" + xSqrd + "\t" + rtp + "\t" + adjustedPValue;
+            string expectedLine = chr + "\t" + left + "\t" + right + "\t" + name + "\t" + value + "\t" + strand + "\t" + xSqrd + "\t" + rtp + "\t" + adjustedPValue;
             string readLine = "";
             var sampleFolder = Array.Find(Directory.GetDirectories(path), (string f) => { return f.Contains(_sidfm[sampleID]); });
             var file = Array.Find(Directory.GetFiles(sampleFolder), (string f) => { return Path.GetFileNameWithoutExtension(f).Equals(attribute.ToString() + "_mspc_peaks"); });

--- a/CLI.Tests/Main.cs
+++ b/CLI.Tests/Main.cs
@@ -240,9 +240,9 @@ namespace Genometric.MSPC.CLI.Tests
             Assert.Contains("All processes successfully finished", output);
             using (var reader = new StreamReader(Directory.GetFiles(outputPath, "*ConsensusPeaks.bed")[0]))
             {
-                Assert.Equal("chr\tstart\tstop\tname\t-1xlog10(p-value)", reader.ReadLine());
-                Assert.Equal("chr1\t4\t20\tMSPC_Peak_2\t25.219", reader.ReadLine());
-                Assert.Equal("chr1\t25\t45\tMSPC_Peak_1\t12.97", reader.ReadLine());
+                Assert.Equal("chr\tstart\tstop\tname\t-1xlog10(p-value)\tstrand", reader.ReadLine());
+                Assert.Equal("chr1\t4\t20\tMSPC_Peak_2\t25.219\t.", reader.ReadLine());
+                Assert.Equal("chr1\t25\t45\tMSPC_Peak_1\t12.97\t.", reader.ReadLine());
                 Assert.Null(reader.ReadLine());
             }
 
@@ -253,11 +253,11 @@ namespace Genometric.MSPC.CLI.Tests
             string line;
             using (var reader = new StreamReader(Directory.GetFiles(dirs[0], "*TruePositive.bed")[0]))
             {
-                Assert.Equal("chr\tstart\tstop\tname\t-1xlog10(p-value)", reader.ReadLine());
+                Assert.Equal("chr\tstart\tstop\tname\t-1xlog10(p-value)\tstrand", reader.ReadLine());
                 line = reader.ReadLine();
-                Assert.True("chr1\t10\t20\tmspc_peak_1\t7.12" == line || "chr1\t4\t12\tmspc_peak_3\t19.9" == line);
+                Assert.True("chr1\t10\t20\tmspc_peak_1\t7.12\t." == line || "chr1\t4\t12\tmspc_peak_3\t19.9\t." == line);
                 line = reader.ReadLine();
-                Assert.True("chr1\t25\t35\tmspc_peak_2\t5.507" == line || "chr1\t30\t45\tmspc_peak_4\t9" == line);
+                Assert.True("chr1\t25\t35\tmspc_peak_2\t5.507\t." == line || "chr1\t30\t45\tmspc_peak_4\t9\t." == line);
                 Assert.Null(reader.ReadLine());
             }
 
@@ -265,11 +265,11 @@ namespace Genometric.MSPC.CLI.Tests
             Assert.True(Directory.GetFiles(dirs[1]).Length == 14);
             using (var reader = new StreamReader(Directory.GetFiles(dirs[1], "*TruePositive.bed")[0]))
             {
-                Assert.Equal("chr\tstart\tstop\tname\t-1xlog10(p-value)", reader.ReadLine());
+                Assert.Equal("chr\tstart\tstop\tname\t-1xlog10(p-value)\tstrand", reader.ReadLine());
                 line = reader.ReadLine();
-                Assert.True("chr1\t10\t20\tmspc_peak_1\t7.12" == line || "chr1\t4\t12\tmspc_peak_3\t19.9" == line);
+                Assert.True("chr1\t10\t20\tmspc_peak_1\t7.12\t." == line || "chr1\t4\t12\tmspc_peak_3\t19.9\t." == line);
                 line = reader.ReadLine();
-                Assert.True("chr1\t25\t35\tmspc_peak_2\t5.507" == line || "chr1\t30\t45\tmspc_peak_4\t9" == line);
+                Assert.True("chr1\t25\t35\tmspc_peak_2\t5.507\t." == line || "chr1\t30\t45\tmspc_peak_4\t9\t." == line);
                 Assert.Null(reader.ReadLine());
             }
 

--- a/CLI.Tests/Main.cs
+++ b/CLI.Tests/Main.cs
@@ -2,13 +2,17 @@
 // The Genometric organization licenses this file to you under the GNU General Public License v3.0 (GPLv3).
 // See the LICENSE file in the project root for more information.
 
+using Genometric.GeUtilities.Intervals.Model;
 using Genometric.GeUtilities.Intervals.Parsers;
+using Genometric.GeUtilities.Intervals.Parsers.Model;
 using Genometric.MSPC.CLI.Tests.MockTypes;
+using Genometric.MSPC.Core.Model;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Security;
 using System.Text.RegularExpressions;
 using Xunit;
@@ -37,9 +41,14 @@ namespace Genometric.MSPC.CLI.Tests
             }
         }
 
-        public static string GetFilename(string prefix)
+        public static string GetFilename(string prefix, string postfix = ".bed")
         {
-            return $"{prefix}{DateTimeOffset.Now.ToUnixTimeMilliseconds}";
+            var rnd = new Random();
+            return
+                $"{prefix}" +
+                $"{DateTimeOffset.Now.ToUnixTimeMilliseconds()}" +
+                $"{rnd.Next(1000, 9999)}" +
+                $"{postfix}";
         }
 
         private static void WriteSampleFiles(out string rep1Filename, out string rep2Filename, out string culture)
@@ -781,6 +790,79 @@ namespace Genometric.MSPC.CLI.Tests
 
             var isAValidPath = TryGetFullPath(loggedOutputPath, out _);
             Assert.True(isAValidPath);
+        }
+
+        [Fact]
+        public void ReadProcessWriteStranded()
+        {
+            // Arrange
+            Result x;
+
+            // Act
+            var tmpMspc = new TmpMspc();
+            x = tmpMspc.Run(stranded: true);  // -w 1e-2 -s 1e-8 -r bio
+            var outputs = new Dictionary<string, Dictionary<Attributes, Bed<Peak>>>();
+            var outputPath = x.Config.OutputPath;
+            foreach (var inputFilename in x.Config.InputFiles)
+            {
+                outputs.Add(inputFilename, new Dictionary<Attributes, Bed<Peak>>());
+                var sampleFolder =
+                    Directory.GetDirectories(
+                        outputPath).First((x) =>
+                        {
+                            return
+                                Path.GetFileName(x) ==
+                                Path.GetFileNameWithoutExtension(inputFilename);
+                        });
+
+                foreach (var attr in Enum.GetValues<Attributes>())
+                {
+                    var bedParser = new BedParser(new BedColumns() { Strand = 5 })
+                    {
+                        PValueFormat = PValueFormats.minus1_Log10_pValue
+                    };
+                    outputs[inputFilename].Add(
+                        attr,
+                        bedParser.Parse(
+                            Path.Join(sampleFolder, attr.ToString() + ".bed")));
+                }
+            }
+            tmpMspc.Dispose();
+
+            // Assert
+            var r1 = outputs[x.Config.InputFiles[0]];
+            var r2 = outputs[x.Config.InputFiles[1]];
+
+            var r1c = r1[Attributes.Confirmed].Chromosomes["chr1"];
+            var r2c = r2[Attributes.Confirmed].Chromosomes["chr1"];
+            Assert.True(r1c.Strands.ContainsKey('+'));
+            Assert.True(r1c.Strands.ContainsKey('-'));
+            Assert.False(r1c.Strands.ContainsKey('.'));
+            Assert.True(r2c.Strands.ContainsKey('+'));
+            Assert.True(r2c.Strands.ContainsKey('-'));
+            Assert.False(r2c.Strands.ContainsKey('.'));
+            Assert.True(r1c.Strands['+'].Intervals.Count == 1);
+            Assert.True(r1c.Strands['-'].Intervals.Count == 2);
+            Assert.True(r2c.Strands['+'].Intervals.Count == 2);
+            Assert.True(r2c.Strands['-'].Intervals.Count == 2);
+
+            var r1d = r1[Attributes.Discarded].Chromosomes["chr1"];
+            var r2d = r2[Attributes.Discarded].Chromosomes["chr1"];
+            Assert.True(r1d.Strands.ContainsKey('+'));
+            Assert.False(r1d.Strands.ContainsKey('-'));
+            Assert.False(r1d.Strands.ContainsKey('.'));
+            Assert.True(r2d.Strands.ContainsKey('+'));
+            Assert.False(r2d.Strands.ContainsKey('-'));
+            Assert.False(r2d.Strands.ContainsKey('.'));
+            Assert.True(r1d.Strands['+'].Intervals.Count == 1);
+            Assert.True(r2d.Strands['+'].Intervals.Count == 1);
+
+            Assert.True(r1[Attributes.Background].Chromosomes.Count == 0);
+            var r2b = r2[Attributes.Background].Chromosomes["chr1"];
+            Assert.True(r2b.Strands.ContainsKey('+'));
+            Assert.True(r2b.Strands.ContainsKey('-'));
+            Assert.True(r2b.Strands['+'].Intervals.Count == 1);
+            Assert.True(r2b.Strands['-'].Intervals.Count == 1);
         }
 
         private static bool TryGetFullPath(string path, out string result)

--- a/CLI.Tests/MockTypes/MExporter.cs
+++ b/CLI.Tests/MockTypes/MExporter.cs
@@ -2,22 +2,21 @@
 // The Genometric organization licenses this file to you under the GNU General Public License v3.0 (GPLv3).
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using Genometric.GeUtilities.Intervals.Model;
 using Genometric.MSPC.CLI.Exporter;
 using Genometric.MSPC.CLI.Interfaces;
 using Genometric.MSPC.Core.Model;
+using System;
+using System.Collections.Generic;
 
 namespace Genometric.MSPC.CLI.Tests.MockTypes
 {
     public class MExporter : IExporter<Peak>
     {
         public void Export(
-            Dictionary<uint, string> fileNames, 
-            ReadOnlyDictionary<uint, Result<Peak>> results, 
-            ReadOnlyDictionary<string, List<ProcessedPeak<Peak>>> consensusPeaks, 
+            Dictionary<uint, string> fileNames,
+            Dictionary<uint, Result<Peak>> results,
+            Dictionary<string, Dictionary<char, List<ProcessedPeak<Peak>>>> consensusPeaks,
             Options options)
         {
             throw new NotImplementedException();

--- a/CLI.Tests/Results.cs
+++ b/CLI.Tests/Results.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Genometric.MSPC.CLI.CommandLineInterface;
+using System.Collections.Generic;
 
 namespace Genometric.MSPC.CLI.Tests
 {
@@ -6,17 +7,23 @@ namespace Genometric.MSPC.CLI.Tests
     {
         public int ExitCode { get; }
         public string ConsoleOutput { get; }
+        public CliConfig Config { get; }
         public IReadOnlyCollection<string> Logs { get; }
 
         public Result(int exitCode, string consoleOutput) :
             this(exitCode, consoleOutput, new List<string>())
         { }
 
-        public Result(int exitCode, string consoleOutput, IReadOnlyCollection<string> logs)
+        public Result(
+            int exitCode,
+            string consoleOutput,
+            IReadOnlyCollection<string> logs,
+            CliConfig config = null)
         {
             ExitCode = exitCode;
             ConsoleOutput = consoleOutput;
             Logs = logs;
+            Config = config;
         }
     }
 }

--- a/CLI/CommandLineInterface/CliConfig.cs
+++ b/CLI/CommandLineInterface/CliConfig.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Genometric.MSPC.CLI.CommandLineInterface
 {
-    internal class CliConfig : Config
+    public class CliConfig : Config
     {
         public IReadOnlyList<string> InputFiles { get; }
 

--- a/CLI/Interfaces/IExporter.cs
+++ b/CLI/Interfaces/IExporter.cs
@@ -6,17 +6,16 @@ using Genometric.GeUtilities.IGenomics;
 using Genometric.MSPC.CLI.Exporter;
 using Genometric.MSPC.Core.Model;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace Genometric.MSPC.CLI.Interfaces
 {
     public interface IExporter<I>
-        where I: IPeak
+        where I : IPeak
     {
         void Export(
             Dictionary<uint, string> fileNames,
-            ReadOnlyDictionary<uint, Result<I>> results,
-            ReadOnlyDictionary<string, List<ProcessedPeak<I>>> consensusPeaks,
+            Dictionary<uint, Result<I>> results,
+            Dictionary<string, Dictionary<char, List<ProcessedPeak<I>>>> consensusPeaks,
             Options options);
     }
 }

--- a/CLI/Logging/Logger.cs
+++ b/CLI/Logging/Logger.cs
@@ -13,7 +13,6 @@ using log4net.Layout;
 using log4net.Repository.Hierarchy;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.CommandLine;
 using System.IO;
 using System.Reflection;
@@ -240,8 +239,8 @@ namespace Genometric.MSPC.CLI.Logging
         public void LogSummary(
             List<Bed<Peak>> samples,
             Dictionary<uint, string> samplesDict,
-            ReadOnlyDictionary<uint, Result<Peak>> results,
-            ReadOnlyDictionary<string, List<ProcessedPeak<Peak>>> consensusPeaks,
+            Dictionary<uint, Result<Peak>> results,
+            Dictionary<string, Dictionary<char, List<ProcessedPeak<Peak>>>> consensusPeaks,
             List<Attributes> exportedAttributes = null)
         {
             // Create table header
@@ -279,7 +278,8 @@ namespace Genometric.MSPC.CLI.Logging
                 {
                     int value = 0;
                     foreach (var chr in res.Value.Chromosomes)
-                        value += chr.Value.Count(att);
+                        foreach (var strand in chr.Value)
+                            value += strand.Value.Count(att);
                     sampleSummary[i++] = (value / totalPeaks).ToString("P");
                 }
 

--- a/Core.Tests/Basic/AdjPValue.cs
+++ b/Core.Tests/Basic/AdjPValue.cs
@@ -13,7 +13,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
     public class AdjPValue
     {
         private readonly string _chr = "chr1";
-        private readonly char _strand = '*';
+        private readonly char _strand = '.';
 
         [Fact]
         public void ComputeAdjustedPValue()
@@ -25,7 +25,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
             var sB = new Bed<Peak>();
             sB.Add(new Peak(left: 5, right: 12, value: 0.01), _chr, _strand);
             sB.Add(new Peak(left: 50, right: 120, value: 0.001), _chr, _strand);
-            
+
             var mspc = new Mspc();
             mspc.AddSample(0, sA);
             mspc.AddSample(1, sB);
@@ -36,8 +36,13 @@ namespace Genometric.MSPC.Core.Tests.Basic
             var res = mspc.Run(config);
 
             // Assert
-            Assert.True(res[0].Chromosomes[_chr].Get(Attributes.TruePositive).First().AdjPValue == 0.01);
-            Assert.True(res[0].Chromosomes[_chr].Get(Attributes.TruePositive).Last().AdjPValue == 0.002);
+
+            foreach (var strand in res[0].Chromosomes[_chr])
+            {
+                var x = strand.Value;
+                Assert.True(x.Get(Attributes.TruePositive).First().AdjPValue == 0.01);
+                Assert.True(x.Get(Attributes.TruePositive).Last().AdjPValue == 0.002);
+            }
         }
     }
 }

--- a/Core.Tests/Basic/C.cs
+++ b/Core.Tests/Basic/C.cs
@@ -14,7 +14,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
     public class C
     {
         private readonly string _chr = "chr1";
-        private readonly char _strand = '*';
+        private readonly char _strand = '.';
 
         //                        r11
         // Sample 1: ---------███████████----------
@@ -59,7 +59,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
             // Arrange
             uint id = 0;
             var mspc = new Mspc();
-            foreach(var peak in GetPeaks(samplesCount))
+            foreach (var peak in GetPeaks(samplesCount))
             {
                 var sample = new Bed<Peak>();
                 sample.Add(peak, _chr, _strand);
@@ -70,8 +70,12 @@ namespace Genometric.MSPC.Core.Tests.Basic
             var res = mspc.Run(new Config(ReplicateType.Biological, 1e-4, 1e-8, 1e-8, c, 1F, MultipleIntersections.UseLowestPValue));
 
             // Assert
-            Assert.True(res[0].Chromosomes[_chr].Get(Attributes.Confirmed).Count() == confirmedPeaksCount);
-            Assert.True(res[0].Chromosomes[_chr].Get(Attributes.Discarded).Count() == discardedPeaksCount);
+            foreach (var strand in res[0].Chromosomes[_chr])
+            {
+                var x = strand.Value;
+                Assert.True(x.Get(Attributes.Confirmed).Count() == confirmedPeaksCount);
+                Assert.True(x.Get(Attributes.Discarded).Count() == discardedPeaksCount);
+            }
         }
     }
 }

--- a/Core.Tests/Basic/ColocalizationCount.cs
+++ b/Core.Tests/Basic/ColocalizationCount.cs
@@ -12,6 +12,9 @@ namespace Genometric.MSPC.Core.Tests.Basic
 {
     public class ColocalizationCount
     {
+        private const string _chr = "chr1";
+        private const char _strand = '.';
+
         [Theory]
         [InlineData(1, 1)]
         [InlineData(2, 0)]
@@ -19,10 +22,10 @@ namespace Genometric.MSPC.Core.Tests.Basic
         {
             // Arrange
             var sA = new Bed<Peak>();
-            sA.Add(new Peak(left: 10, right: 20, value: 0.01), "chr1", '*');
+            sA.Add(new Peak(left: 10, right: 20, value: 0.01), _chr, _strand);
 
             var sB = new Bed<Peak>();
-            sB.Add(new Peak(left: 30, right: 40, value: 0.01), "chr1", '*');
+            sB.Add(new Peak(left: 30, right: 40, value: 0.01), _chr, _strand);
 
             var mspc = new Mspc();
             mspc.AddSample(0, sA);
@@ -36,8 +39,8 @@ namespace Genometric.MSPC.Core.Tests.Basic
             // Assert
             Assert.True(new[]
             {
-                res[0].Chromosomes["chr1"].Get(Attributes.Confirmed).Count(),
-                res[1].Chromosomes["chr1"].Get(Attributes.Confirmed).Count()
+                res[0].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count(),
+                res[1].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count()
             }.All(x => x == expected));
         }
 
@@ -48,10 +51,10 @@ namespace Genometric.MSPC.Core.Tests.Basic
         {
             // Arrange
             var sA = new Bed<Peak>();
-            sA.Add(new Peak(left: 10, right: 20, value: 0.01), "chr1", '*');
+            sA.Add(new Peak(left: 10, right: 20, value: 0.01), _chr, _strand);
 
             var sB = new Bed<Peak>();
-            sB.Add(new Peak(left: 5, right: 40, value: 0.01), "chr1", '*');
+            sB.Add(new Peak(left: 5, right: 40, value: 0.01), _chr, _strand);
 
             var mspc = new Mspc();
             mspc.AddSample(0, sA);
@@ -65,8 +68,8 @@ namespace Genometric.MSPC.Core.Tests.Basic
             // Assert
             Assert.True(new[]
             {
-                res[0].Chromosomes["chr1"].Get(Attributes.Confirmed).Count(),
-                res[1].Chromosomes["chr1"].Get(Attributes.Confirmed).Count()
+                res[0].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count(),
+                res[1].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count()
             }.All(x => x == expected));
         }
 
@@ -78,13 +81,13 @@ namespace Genometric.MSPC.Core.Tests.Basic
         {
             // Arrange
             var sA = new Bed<Peak>();
-            sA.Add(new Peak(left: 10, right: 20, value: 0.01), "chr1", '*');
+            sA.Add(new Peak(left: 10, right: 20, value: 0.01), _chr, _strand);
 
             var sB = new Bed<Peak>();
-            sB.Add(new Peak(left: 5, right: 12, value: 0.01), "chr1", '*');
+            sB.Add(new Peak(left: 5, right: 12, value: 0.01), _chr, _strand);
 
             var sC = new Bed<Peak>();
-            sC.Add(new Peak(left: 18, right: 25, value: 0.01), "chr1", '*');
+            sC.Add(new Peak(left: 18, right: 25, value: 0.01), _chr, _strand);
 
             var mspc = new Mspc();
             mspc.AddSample(0, sA);
@@ -99,9 +102,9 @@ namespace Genometric.MSPC.Core.Tests.Basic
             // Assert
             Assert.True(new[]
             {
-                res[0].Chromosomes["chr1"].Get(Attributes.Confirmed).Count(),
-                res[1].Chromosomes["chr1"].Get(Attributes.Confirmed).Count(),
-                res[2].Chromosomes["chr1"].Get(Attributes.Confirmed).Count()
+                res[0].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count(),
+                res[1].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count(),
+                res[2].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count()
             }.All(x => x == expected));
         }
 
@@ -113,13 +116,13 @@ namespace Genometric.MSPC.Core.Tests.Basic
         {
             // Arrange
             var sA = new Bed<Peak>();
-            sA.Add(new Peak(left: 10, right: 20, value: 0.01), "chr1", '*');
+            sA.Add(new Peak(left: 10, right: 20, value: 0.01), _chr, _strand);
 
             var sB = new Bed<Peak>();
-            sB.Add(new Peak(left: 5, right: 18, value: 0.01), "chr1", '*');
+            sB.Add(new Peak(left: 5, right: 18, value: 0.01), _chr, _strand);
 
             var sC = new Bed<Peak>();
-            sC.Add(new Peak(left: 14, right: 25, value: 0.01), "chr1", '*');
+            sC.Add(new Peak(left: 14, right: 25, value: 0.01), _chr, _strand);
 
             var mspc = new Mspc();
             mspc.AddSample(0, sA);
@@ -134,9 +137,9 @@ namespace Genometric.MSPC.Core.Tests.Basic
             // Assert
             Assert.True(new[]
             {
-                res[0].Chromosomes["chr1"].Get(Attributes.Confirmed).Count(),
-                res[1].Chromosomes["chr1"].Get(Attributes.Confirmed).Count(),
-                res[2].Chromosomes["chr1"].Get(Attributes.Confirmed).Count()
+                res[0].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count(),
+                res[1].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count(),
+                res[2].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count()
             }.All(x => x == expected));
         }
 
@@ -148,13 +151,13 @@ namespace Genometric.MSPC.Core.Tests.Basic
         {
             // Arrange
             var sA = new Bed<Peak>();
-            sA.Add(new Peak(left: 10, right: 20, value: 0.01), "chr1", '*');
+            sA.Add(new Peak(left: 10, right: 20, value: 0.01), _chr, _strand);
 
             var sB = new Bed<Peak>();
-            sB.Add(new Peak(left: 5, right: 8, value: 0.01), "chr1", '*');
+            sB.Add(new Peak(left: 5, right: 8, value: 0.01), _chr, _strand);
 
             var sC = new Bed<Peak>();
-            sC.Add(new Peak(left: 24, right: 25, value: 0.01), "chr1", '*');
+            sC.Add(new Peak(left: 24, right: 25, value: 0.01), _chr, _strand);
 
             var mspc = new Mspc();
             mspc.AddSample(0, sA);
@@ -169,9 +172,9 @@ namespace Genometric.MSPC.Core.Tests.Basic
             // Assert
             Assert.True(new[]
             {
-                res[0].Chromosomes["chr1"].Get(Attributes.Confirmed).Count(),
-                res[1].Chromosomes["chr1"].Get(Attributes.Confirmed).Count(),
-                res[2].Chromosomes["chr1"].Get(Attributes.Confirmed).Count()
+                res[0].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count(),
+                res[1].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count(),
+                res[2].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count()
             }.All(x => x == expected));
         }
 
@@ -180,19 +183,19 @@ namespace Genometric.MSPC.Core.Tests.Basic
         {
             // Arrange
             var sA = new Bed<Peak>();
-            sA.Add(new Peak(left: 10, right: 20, value: 0.01), "chr1", '*');
+            sA.Add(new Peak(left: 10, right: 20, value: 0.01), _chr, _strand);
 
             var sB = new Bed<Peak>();
-            sB.Add(new Peak(left: 5, right: 18, value: 0.01), "chr1", '*');
+            sB.Add(new Peak(left: 5, right: 18, value: 0.01), _chr, _strand);
 
             var sC = new Bed<Peak>();
-            sC.Add(new Peak(left: 14, right: 25, value: 0.01), "chr1", '*');
+            sC.Add(new Peak(left: 14, right: 25, value: 0.01), _chr, _strand);
 
             var sD = new Bed<Peak>();
-            sD.Add(new Peak(left: 35, right: 40, value: 0.01), "chr1", '*');
+            sD.Add(new Peak(left: 35, right: 40, value: 0.01), _chr, _strand);
 
             var sE = new Bed<Peak>();
-            sE.Add(new Peak(left: 43, right: 50, value: 0.01), "chr1", '*');
+            sE.Add(new Peak(left: 43, right: 50, value: 0.01), _chr, _strand);
 
             var mspc = new Mspc();
             mspc.AddSample(0, sA);
@@ -209,11 +212,11 @@ namespace Genometric.MSPC.Core.Tests.Basic
             // Assert
             Assert.True(new[]
             {
-                res[0].Chromosomes["chr1"].Get(Attributes.Confirmed).Count(),
-                res[1].Chromosomes["chr1"].Get(Attributes.Confirmed).Count(),
-                res[2].Chromosomes["chr1"].Get(Attributes.Confirmed).Count(),
-                res[3].Chromosomes["chr1"].Get(Attributes.Confirmed).Count(),
-                res[4].Chromosomes["chr1"].Get(Attributes.Confirmed).Count()
+                res[0].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count(),
+                res[1].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count(),
+                res[2].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count(),
+                res[3].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count(),
+                res[4].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count()
             }.All(x => x == 1));
         }
 
@@ -222,14 +225,14 @@ namespace Genometric.MSPC.Core.Tests.Basic
         {
             // Arrange
             var sA = new Bed<Peak>();
-            sA.Add(new Peak(left: 10, right: 20, value: 0.01), "chr1", '*');
+            sA.Add(new Peak(left: 10, right: 20, value: 0.01), _chr, _strand);
 
             var sB = new Bed<Peak>();
-            sB.Add(new Peak(left: 5, right: 12, value: 0.01), "chr1", '*');
-            sB.Add(new Peak(left: 14, right: 22, value: 0.01), "chr1", '*');
+            sB.Add(new Peak(left: 5, right: 12, value: 0.01), _chr, _strand);
+            sB.Add(new Peak(left: 14, right: 22, value: 0.01), _chr, _strand);
 
             var sC = new Bed<Peak>();
-            sC.Add(new Peak(left: 24, right: 25, value: 0.01), "chr1", '*');
+            sC.Add(new Peak(left: 24, right: 25, value: 0.01), _chr, _strand);
 
             var mspc = new Mspc();
             mspc.AddSample(0, sA);
@@ -242,7 +245,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
             var res = mspc.Run(config);
 
             // Assert
-            Assert.False(res[0].Chromosomes["chr1"].Get(Attributes.Confirmed).Any());
+            Assert.False(res[0].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Any());
         }
 
         [Fact]
@@ -250,16 +253,16 @@ namespace Genometric.MSPC.Core.Tests.Basic
         {
             // Arrange
             var sA = new Bed<Peak>();
-            sA.Add(new Peak(left: 10, right: 20, value: 0.01, hashSeed: "0"), "chr1", '*');
-            sA.Add(new Peak(left: 10, right: 20, value: 0.01, hashSeed: "1"), "chr1", '*');
-            sA.Add(new Peak(left: 10, right: 20, value: 0.01, hashSeed: "2"), "chr1", '*');
-            sA.Add(new Peak(left: 10, right: 20, value: 0.01, hashSeed: "3"), "chr1", '*');
+            sA.Add(new Peak(left: 10, right: 20, value: 0.01, hashSeed: "0"), _chr, _strand);
+            sA.Add(new Peak(left: 10, right: 20, value: 0.01, hashSeed: "1"), _chr, _strand);
+            sA.Add(new Peak(left: 10, right: 20, value: 0.01, hashSeed: "2"), _chr, _strand);
+            sA.Add(new Peak(left: 10, right: 20, value: 0.01, hashSeed: "3"), _chr, _strand);
 
             var sB = new Bed<Peak>();
-            sB.Add(new Peak(left: 5, right: 12, value: 0.01), "chr1", '*');
+            sB.Add(new Peak(left: 5, right: 12, value: 0.01), _chr, _strand);
 
             var sC = new Bed<Peak>();
-            sC.Add(new Peak(left: 18, right: 25, value: 0.01), "chr1", '*');
+            sC.Add(new Peak(left: 18, right: 25, value: 0.01), _chr, _strand);
 
             var mspc = new Mspc();
             mspc.AddSample(0, sA);
@@ -272,7 +275,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
             var res = mspc.Run(config);
 
             // Assert
-            Assert.True(res[0].Chromosomes["chr1"].Count(Attributes.Confirmed) == 0);
+            Assert.True(res[0].Chromosomes[_chr][_strand].Count(Attributes.Confirmed) == 0);
         }
 
         [Fact]
@@ -284,16 +287,16 @@ namespace Genometric.MSPC.Core.Tests.Basic
             for (uint i = 0; i < sampleCount - 2; i++)
             {
                 var bed = new Bed<Peak>();
-                bed.Add(new Peak(10, 20, 0.01), "chr1", '*');
+                bed.Add(new Peak(10, 20, 0.01), _chr, _strand);
                 mspc.AddSample(i, bed);
             }
 
             var bedB = new Bed<Peak>();
-            bedB.Add(new Peak(8, 12, 0.01), "chr1", '*');
+            bedB.Add(new Peak(8, 12, 0.01), _chr, _strand);
             mspc.AddSample((uint)sampleCount - 2, bedB);
 
             var bedC = new Bed<Peak>();
-            bedC.Add(new Peak(18, 25, 0.01), "chr1", '*');
+            bedC.Add(new Peak(18, 25, 0.01), _chr, _strand);
             mspc.AddSample((uint)sampleCount - 1, bedC);
 
             var config = new Config(ReplicateType.Biological, 1, 1, 1, sampleCount, 1F, MultipleIntersections.UseLowestPValue);
@@ -303,7 +306,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
 
             // Assert
             for (uint i = 0; i < sampleCount; i++)
-                Assert.True(res[i].Chromosomes["chr1"].Count(Attributes.Confirmed) == 1);
+                Assert.True(res[i].Chromosomes[_chr][_strand].Count(Attributes.Confirmed) == 1);
         }
     }
 }

--- a/Core.Tests/Basic/MultipleIntersections.cs
+++ b/Core.Tests/Basic/MultipleIntersections.cs
@@ -6,7 +6,7 @@
 using Genometric.GeUtilities.Intervals.Model;
 using Genometric.GeUtilities.Intervals.Parsers.Model;
 using Genometric.MSPC.Core.Model;
-using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -15,7 +15,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
     public class ChooseOnePeakFromManyOverlappingPeaks
     {
         private readonly string _chr = "chr1";
-        private readonly char _strand = '*';
+        private readonly char _strand = '.';
 
         //                            r11
         // Sample 1: ---------█████████████████████------
@@ -27,7 +27,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
         private readonly static Peak r22 = new Peak(left: 16, right: 20, name: "r22", value: 1e-6);
         private readonly static Peak r23 = new Peak(left: 26, right: 32, name: "r23", value: 1e-9);
 
-        private ReadOnlyDictionary<uint, Result<Peak>> InitializeAndRun(MultipleIntersections miChoice, bool trackSupportingPeaks = false)
+        private Dictionary<uint, Result<Peak>> InitializeAndRun(MultipleIntersections miChoice, bool trackSupportingPeaks = false)
         {
             // Arrange
             var sA = new Bed<Peak>();
@@ -53,7 +53,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
             var res = InitializeAndRun(MultipleIntersections.UseLowestPValue, true);
 
             // Assert
-            Assert.True(res[0].Chromosomes[_chr].Get(Attributes.Confirmed).ToList()[0].SupportingPeaks[0].Source.CompareTo(r23) == 0);
+            Assert.True(res[0].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).ToList()[0].SupportingPeaks[0].Source.CompareTo(r23) == 0);
         }
 
         [Fact]
@@ -63,7 +63,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
             var res = InitializeAndRun(MultipleIntersections.UseHighestPValue, true);
 
             // Assert
-            Assert.True(res[0].Chromosomes[_chr].Get(Attributes.Confirmed).ToList()[0].SupportingPeaks[0].Source.CompareTo(r21) == 0);
+            Assert.True(res[0].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).ToList()[0].SupportingPeaks[0].Source.CompareTo(r21) == 0);
         }
     }
 }

--- a/Core.Tests/Basic/PeakReason.cs
+++ b/Core.Tests/Basic/PeakReason.cs
@@ -5,7 +5,7 @@
 using Genometric.GeUtilities.Intervals.Model;
 using Genometric.GeUtilities.Intervals.Parsers.Model;
 using Genometric.MSPC.Core.Model;
-using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -20,9 +20,9 @@ namespace Genometric.MSPC.Core.Tests.Basic
     public class PeakReason
     {
         private readonly string _chr = "chr1";
-        private readonly char _strand = '*';
+        private readonly char _strand = '.';
 
-        private ReadOnlyDictionary<uint, Result<Peak>> RunMSPCAndReturnResult(Config config)
+        private Dictionary<uint, Result<Peak>> RunMSPCAndReturnResult(Config config)
         {
             var sA = new Bed<Peak>();
             sA.Add(new Peak(left: 10, right: 20, value: 1E-5), _chr, _strand);
@@ -45,7 +45,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
                 new Config(ReplicateType.Biological, 1E-2, 1E-4, 1E-4, 1, 1F, MultipleIntersections.UseLowestPValue));
 
             // Assert
-            Assert.True(res[0].Chromosomes[_chr].Get(Attributes.Confirmed).First().Reason == "");
+            Assert.True(res[0].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).First().Reason == "");
         }
 
 
@@ -59,7 +59,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
             // Assert
             Assert.Equal(
                 "X-squared is below chi-squared of Gamma.",
-                res[0].Chromosomes[_chr].Get(Attributes.Discarded).First().Reason);
+                res[0].Chromosomes[_chr][_strand].Get(Attributes.Discarded).First().Reason);
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
             // Assert
             Assert.Equal(
                 "Intersecting peaks count doesn't comply minimum C requirement.",
-                res[0].Chromosomes[_chr].Get(Attributes.Discarded).First().Reason);
+                res[0].Chromosomes[_chr][_strand].Get(Attributes.Discarded).First().Reason);
         }
     }
 }

--- a/Core.Tests/Basic/TConsensusPeaks.cs
+++ b/Core.Tests/Basic/TConsensusPeaks.cs
@@ -16,10 +16,10 @@ namespace Genometric.MSPC.Core.Tests.Basic
     public class TConsensusPeaks
     {
         private readonly string _chr = "chr1";
-        private readonly char _strand = '*';
+        private readonly char _strand = '.';
         private readonly string[] _chrs = new string[] { "chr1", "chr2", "chr3", "chr9", "chrx" };
 
-        private ReadOnlyDictionary<string, List<ProcessedPeak<Peak>>> GetSampleConsensusPeaks(float alpha= 1e-15F)
+        private Dictionary<string, Dictionary<char, List<ProcessedPeak<Peak>>>> GetSampleConsensusPeaks(float alpha= 1e-15F)
         {
             ///                 r11                 r12
             /// Sample 0: ----▓▓▓▓▓▓--------------▓▓▓▓▓▓-----------------------
@@ -73,7 +73,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
 
             // Act
             mspc.Run(new Config(ReplicateType.Biological, 1, 1, 1, 1, 1F, MultipleIntersections.UseLowestPValue));
-            var cp = mspc.GetConsensusPeaks()[_chr].First();
+            var cp = mspc.GetConsensusPeaks()[_chr][_strand].First();
 
             // Assert
             Assert.True(cp.Source.Left == cLeft && cp.Source.Right == cRight);
@@ -86,10 +86,10 @@ namespace Genometric.MSPC.Core.Tests.Basic
             var cPeaks = GetSampleConsensusPeaks();
 
             // Assert
-            Assert.True(cPeaks[_chrs[0]][0].Source.Left == 2 && cPeaks[_chrs[0]][0].Source.Right == 26);
-            Assert.True(cPeaks[_chrs[1]][0].Source.Left == 36 && cPeaks[_chrs[1]][0].Source.Right == 40);
-            Assert.True(cPeaks[_chrs[2]][0].Source.Left == 50 && cPeaks[_chrs[2]][0].Source.Right == 60);
-            Assert.True(cPeaks[_chrs[4]][0].Source.Left == 70 && cPeaks[_chrs[4]][0].Source.Right == 90);
+            Assert.True(cPeaks[_chrs[0]][_strand][0].Source.Left == 2 && cPeaks[_chrs[0]][_strand][0].Source.Right == 26);
+            Assert.True(cPeaks[_chrs[1]][_strand][0].Source.Left == 36 && cPeaks[_chrs[1]][_strand][0].Source.Right == 40);
+            Assert.True(cPeaks[_chrs[2]][_strand][0].Source.Left == 50 && cPeaks[_chrs[2]][_strand][0].Source.Right == 60);
+            Assert.True(cPeaks[_chrs[4]][_strand][0].Source.Left == 70 && cPeaks[_chrs[4]][_strand][0].Source.Right == 90);
         }
 
         [Fact]
@@ -97,7 +97,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
         {
             // Arrange and Act
             var cPeaks = GetSampleConsensusPeaks();
-            var cPeak = cPeaks[_chrs[0]].First(x => x.Source.Left == 2 && x.Source.Right == 26);
+            var cPeak = cPeaks[_chrs[0]][_strand].First(x => x.Source.Left == 2 && x.Source.Right == 26);
 
             // Assert
             Assert.True(Math.Round(cPeak.XSquared, 6) == 112.154559);
@@ -108,7 +108,7 @@ namespace Genometric.MSPC.Core.Tests.Basic
         {
             // Arrange and Act
             var cPeaks = GetSampleConsensusPeaks();
-            var cPeak = cPeaks[_chrs[0]].First(x => x.Source.Left == 2 && x.Source.Right == 26);
+            var cPeak = cPeaks[_chrs[0]][_strand].First(x => x.Source.Left == 2 && x.Source.Right == 26);
 
             // Assert
             Assert.True(cPeak.RTP.ToString("E5") == "7.21069E-022");
@@ -119,10 +119,10 @@ namespace Genometric.MSPC.Core.Tests.Basic
         {
             // Arrange & Act
             var cPeaks = GetSampleConsensusPeaks();
-            var r1 = cPeaks[_chrs[0]].First(x => x.Source.Left == 2);
-            var r2 = cPeaks[_chrs[1]].First(x => x.Source.Left == 36);
-            var r3 = cPeaks[_chrs[2]].First(x => x.Source.Left == 50);
-            var r4 = cPeaks[_chrs[4]].First(x => x.Source.Left == 70);
+            var r1 = cPeaks[_chrs[0]][_strand].First(x => x.Source.Left == 2);
+            var r2 = cPeaks[_chrs[1]][_strand].First(x => x.Source.Left == 36);
+            var r3 = cPeaks[_chrs[2]][_strand].First(x => x.Source.Left == 50);
+            var r4 = cPeaks[_chrs[4]][_strand].First(x => x.Source.Left == 70);
 
             // Assert
             Assert.Equal("9.614E-022", r1.AdjPValue.ToString("E3"));
@@ -136,10 +136,10 @@ namespace Genometric.MSPC.Core.Tests.Basic
         {
             // Arrange & Act
             var cPeaks = GetSampleConsensusPeaks();
-            var r1 = cPeaks[_chrs[0]].First(x => x.Source.Left == 2);
-            var r2 = cPeaks[_chrs[1]].First(x => x.Source.Left == 36);
-            var r3 = cPeaks[_chrs[2]].First(x => x.Source.Left == 50);
-            var r4 = cPeaks[_chrs[4]].First(x => x.Source.Left == 70);
+            var r1 = cPeaks[_chrs[0]][_strand].First(x => x.Source.Left == 2);
+            var r2 = cPeaks[_chrs[1]][_strand].First(x => x.Source.Left == 36);
+            var r3 = cPeaks[_chrs[2]][_strand].First(x => x.Source.Left == 50);
+            var r4 = cPeaks[_chrs[4]][_strand].First(x => x.Source.Left == 70);
 
             // Assert
             Assert.True(r1.HasAttribute(Attributes.TruePositive));

--- a/Core.Tests/Concurrency/Concurrency.cs
+++ b/Core.Tests/Concurrency/Concurrency.cs
@@ -12,6 +12,8 @@ namespace Genometric.MSPC.Core.Tests.Concurrency
 {
     public class Concurrency
     {
+        private const char _strand = '.';
+
         private Bed<Peak> CreateSample(int offset, int chrCount, int iCount)
         {
             var rtv = new Bed<Peak>();
@@ -25,7 +27,7 @@ namespace Genometric.MSPC.Core.Tests.Concurrency
                             name: "r1" + i
                         ),
                         "chr" + c,
-                        '*');
+                        _strand);
 
             return rtv;
         }
@@ -45,8 +47,8 @@ namespace Genometric.MSPC.Core.Tests.Concurrency
             // Assert
             for (int c = 0; c < 20; c++)
             {
-                Assert.True(res[0].Chromosomes["chr" + c].Get(Attributes.Confirmed).Count() == 1000);
-                Assert.True(res[1].Chromosomes["chr" + c].Get(Attributes.Confirmed).Count() == 2000);
+                Assert.True(res[0].Chromosomes["chr" + c][_strand].Get(Attributes.Confirmed).Count() == 1000);
+                Assert.True(res[1].Chromosomes["chr" + c][_strand].Get(Attributes.Confirmed).Count() == 2000);
             }
         }
 
@@ -65,8 +67,8 @@ namespace Genometric.MSPC.Core.Tests.Concurrency
             // Assert
             for (int c = 0; c < 20; c++)
             {
-                Assert.True(res[0].Chromosomes["chr" + c].Get(Attributes.Confirmed).Count() == 10000);
-                Assert.True(res[1].Chromosomes["chr" + c].Get(Attributes.Confirmed).Count() == 20000);
+                Assert.True(res[0].Chromosomes["chr" + c][_strand].Get(Attributes.Confirmed).Count() == 10000);
+                Assert.True(res[1].Chromosomes["chr" + c][_strand].Get(Attributes.Confirmed).Count() == 20000);
             }
         }
     }

--- a/Core.Tests/Example/Eg1.cs
+++ b/Core.Tests/Example/Eg1.cs
@@ -13,6 +13,9 @@ namespace Genometric.MSPC.Core.Tests.Example
 {
     public class Eg1
     {
+        private const string _chr = "chr1";
+        private const char _strand = '.';
+
         //                 r11                r12
         // Sample 1: --███████████-------████████████----------------------------
         //                           r21             r22        r23
@@ -64,18 +67,18 @@ namespace Genometric.MSPC.Core.Tests.Example
         private Mspc<Peak> InitializeMSPC()
         {
             var sA = new Bed<Peak>();
-            sA.Add(r11, "chr1", '*');
-            sA.Add(r12, "chr1", '*');
+            sA.Add(r11, _chr, _strand);
+            sA.Add(r12, _chr, _strand);
 
             var sB = new Bed<Peak>();
-            sB.Add(r21, "chr1", '*');
-            sB.Add(r22, "chr1", '*');
-            sB.Add(r23, "chr1", '*');
+            sB.Add(r21, _chr, _strand);
+            sB.Add(r22, _chr, _strand);
+            sB.Add(r23, _chr, _strand);
 
             var sC = new Bed<Peak>();
-            sC.Add(r31, "chr1", '*');
-            sC.Add(r32, "chr1", '*');
-            sC.Add(r33, "chr1", '*');
+            sC.Add(r31, _chr, _strand);
+            sC.Add(r32, _chr, _strand);
+            sC.Add(r33, _chr, _strand);
 
             var mspc = new Mspc();
             mspc.AddSample(0, sA);
@@ -95,7 +98,7 @@ namespace Genometric.MSPC.Core.Tests.Example
 
             // Act
             var res = mspc.Run(new Config(replicateType, 1e-4, 1e-8, 1e-4, c, 1F, MultipleIntersections.UseLowestPValue));
-            var qres = res[sampleIndex].Chromosomes["chr1"].Get(processed).FirstOrDefault(x => x.Source.CompareTo(peak) == 0);
+            var qres = res[sampleIndex].Chromosomes[_chr][_strand].Get(processed).FirstOrDefault(x => x.Source.CompareTo(peak) == 0);
 
             // Assert
             Assert.NotNull(qres);
@@ -132,7 +135,7 @@ namespace Genometric.MSPC.Core.Tests.Example
 
             // Act
             var res = mspc.Run(new Config(replicateType, 1e-4, 1e-8, 1e-4, c, 1F, MultipleIntersections.UseLowestPValue));
-            var qres = res[sampleIndex].Chromosomes["chr1"].Get(attribute);
+            var qres = res[sampleIndex].Chromosomes[_chr][_strand].Get(attribute);
 
             // Assert
             Assert.True(qres.Count() == expectedCount);

--- a/Core.Tests/PublicMembers.cs
+++ b/Core.Tests/PublicMembers.cs
@@ -17,7 +17,7 @@ namespace Genometric.MSPC.Core.Tests
     public class PublicMembers
     {
         private readonly string _chr = "chr1";
-        private readonly char _strand = '*';
+        private readonly char _strand = '.';
         private string _status;
         private AutoResetEvent _continueIni;
         private AutoResetEvent _continuePrc;
@@ -26,7 +26,7 @@ namespace Genometric.MSPC.Core.Tests
 
         public enum Status { Init, Process, MTC, Consensu }; 
 
-        private ReadOnlyDictionary<uint, Result<Peak>> RunThenCancelMSPC(int iCount, Status status)
+        private Dictionary<uint, Result<Peak>> RunThenCancelMSPC(int iCount, Status status)
         {
             var sA = new Bed<Peak>();
             var sB = new Bed<Peak>();
@@ -148,7 +148,7 @@ namespace Genometric.MSPC.Core.Tests
             // Arrange
             int c = 10000;
             int tries = 10;
-            ReadOnlyDictionary<uint, Result<Peak>> results = null;
+            Dictionary<uint, Result<Peak>> results = null;
             for (int i = 0; i < tries; i++)
             {
                 // Act
@@ -156,8 +156,8 @@ namespace Genometric.MSPC.Core.Tests
                 if (results.Count > 0 &&
                     results[0].Chromosomes.Count > 0 &&
                     results[0].Chromosomes.ContainsKey(_chr) &&
-                    !results[0].Chromosomes[_chr].Get(Attributes.Confirmed).Any() &&
-                    results[0].Chromosomes[_chr].Get(Attributes.Background).Count() == c)
+                    !results[0].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Any() &&
+                    results[0].Chromosomes[_chr][_strand].Get(Attributes.Background).Count() == c)
                     break;
                 Thread.Sleep(10000);
             }
@@ -167,8 +167,8 @@ namespace Genometric.MSPC.Core.Tests
                     string.Format("Tried CancelCurrentAsyncRun unit test on {0} status for {1} times, all tries failed.", status, tries));
 
             // Assert
-            Assert.True(!results[0].Chromosomes[_chr].Get(Attributes.Confirmed).Any());
-            Assert.True(results[0].Chromosomes[_chr].Get(Attributes.Background).Count() == c);
+            Assert.True(!results[0].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Any());
+            Assert.True(results[0].Chromosomes[_chr][_strand].Get(Attributes.Background).Count() == c);
         }
 
         [Fact]

--- a/Core.Tests/Replicates/BioPValue.cs
+++ b/Core.Tests/Replicates/BioPValue.cs
@@ -13,7 +13,7 @@ namespace Genometric.MSPC.Core.Tests.Replicates
     public class BioPValue
     {
         private readonly string _chr = "chr1";
-        private readonly char _strand = '*';
+        private readonly char _strand = '.';
 
         /// <summary>
         /// This test asserts if MSPC correctly discards a weak peak
@@ -49,9 +49,9 @@ namespace Genometric.MSPC.Core.Tests.Replicates
             var res = mspc.Run(config);
 
             // Assert
-            Assert.True(res[0].Chromosomes[_chr].Get(Attributes.Discarded).Count() == 1);
-            Assert.False(res[0].Chromosomes[_chr].Get(Attributes.Confirmed).Any());
-            Assert.True(res[0].Chromosomes[_chr].Get(Attributes.Discarded).ToList()[0].Source.CompareTo(r11) == 0);
+            Assert.True(res[0].Chromosomes[_chr][_strand].Get(Attributes.Discarded).Count() == 1);
+            Assert.False(res[0].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Any());
+            Assert.True(res[0].Chromosomes[_chr][_strand].Get(Attributes.Discarded).ToList()[0].Source.CompareTo(r11) == 0);
         }
 
         /// <summary>
@@ -92,15 +92,15 @@ namespace Genometric.MSPC.Core.Tests.Replicates
             var res = mspc.Run(config);
 
             // Assert
-            Assert.True(res[0].Chromosomes[_chr].Get(Attributes.Confirmed).Count() == 1);
-            Assert.False(res[0].Chromosomes[_chr].Get(Attributes.Discarded).Any());
-            Assert.True(res[0].Chromosomes[_chr].Get(Attributes.Confirmed).ToList()[0].Source.CompareTo(r11) == 0);
+            Assert.True(res[0].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count() == 1);
+            Assert.False(res[0].Chromosomes[_chr][_strand].Get(Attributes.Discarded).Any());
+            Assert.True(res[0].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).ToList()[0].Source.CompareTo(r11) == 0);
 
-            Assert.True(res[1].Chromosomes[_chr].Get(Attributes.Confirmed).Count() == 1);
-            Assert.True(res[1].Chromosomes[_chr].Get(Attributes.Discarded).Count() == 2);
-            Assert.True(res[1].Chromosomes[_chr].Get(Attributes.Confirmed).ToList()[0].Source.CompareTo(r22) == 0);
-            Assert.True(res[1].Chromosomes[_chr].Get(Attributes.Discarded).ToList()[0].Source.CompareTo(r21) == 0);
-            Assert.True(res[1].Chromosomes[_chr].Get(Attributes.Discarded).ToList()[1].Source.CompareTo(r23) == 0);
+            Assert.True(res[1].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count() == 1);
+            Assert.True(res[1].Chromosomes[_chr][_strand].Get(Attributes.Discarded).Count() == 2);
+            Assert.True(res[1].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).ToList()[0].Source.CompareTo(r22) == 0);
+            Assert.True(res[1].Chromosomes[_chr][_strand].Get(Attributes.Discarded).ToList()[0].Source.CompareTo(r21) == 0);
+            Assert.True(res[1].Chromosomes[_chr][_strand].Get(Attributes.Discarded).ToList()[1].Source.CompareTo(r23) == 0);
         }
     }
 }

--- a/Core.Tests/Replicates/TecPValue.cs
+++ b/Core.Tests/Replicates/TecPValue.cs
@@ -13,7 +13,7 @@ namespace Genometric.MSPC.Core.Tests.Replicates
     public class TecPValue
     {
         private readonly string _chr = "chr1";
-        private readonly char _strand = '*';
+        private readonly char _strand = '.';
 
         /// <summary>
         /// This test asserts if MSPC correctly discards a weak peak
@@ -49,9 +49,9 @@ namespace Genometric.MSPC.Core.Tests.Replicates
             var res = mspc.Run(config);
 
             // Assert
-            Assert.True(res[0].Chromosomes[_chr].Get(Attributes.Discarded).Count() == 1);
-            Assert.False(res[0].Chromosomes[_chr].Get(Attributes.Confirmed).Any());
-            Assert.True(res[0].Chromosomes[_chr].Get(Attributes.Discarded).ToList()[0].Source.CompareTo(r11) == 0);
+            Assert.True(res[0].Chromosomes[_chr][_strand].Get(Attributes.Discarded).Count() == 1);
+            Assert.False(res[0].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Any());
+            Assert.True(res[0].Chromosomes[_chr][_strand].Get(Attributes.Discarded).ToList()[0].Source.CompareTo(r11) == 0);
         }
 
         /// <summary>
@@ -94,15 +94,15 @@ namespace Genometric.MSPC.Core.Tests.Replicates
             var res = mspc.Run(config);
 
             // Assert
-            Assert.False(res[0].Chromosomes[_chr].Get(Attributes.Confirmed).Any());
-            Assert.True(res[0].Chromosomes[_chr].Get(Attributes.Discarded).Count() == 1);
-            Assert.True(res[0].Chromosomes[_chr].Get(Attributes.Discarded).ToList()[0].Source.CompareTo(r11) == 0);
+            Assert.False(res[0].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Any());
+            Assert.True(res[0].Chromosomes[_chr][_strand].Get(Attributes.Discarded).Count() == 1);
+            Assert.True(res[0].Chromosomes[_chr][_strand].Get(Attributes.Discarded).ToList()[0].Source.CompareTo(r11) == 0);
 
-            Assert.True(res[1].Chromosomes[_chr].Get(Attributes.Confirmed).Count() == 1);
-            Assert.True(res[1].Chromosomes[_chr].Get(Attributes.Discarded).Count() == 2);
-            Assert.True(res[1].Chromosomes[_chr].Get(Attributes.Confirmed).ToList()[0].Source.CompareTo(r22) == 0);
-            Assert.True(res[1].Chromosomes[_chr].Get(Attributes.Discarded).ToList()[0].Source.CompareTo(r21) == 0);
-            Assert.True(res[1].Chromosomes[_chr].Get(Attributes.Discarded).ToList()[1].Source.CompareTo(r23) == 0);
+            Assert.True(res[1].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Count() == 1);
+            Assert.True(res[1].Chromosomes[_chr][_strand].Get(Attributes.Discarded).Count() == 2);
+            Assert.True(res[1].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).ToList()[0].Source.CompareTo(r22) == 0);
+            Assert.True(res[1].Chromosomes[_chr][_strand].Get(Attributes.Discarded).ToList()[0].Source.CompareTo(r21) == 0);
+            Assert.True(res[1].Chromosomes[_chr][_strand].Get(Attributes.Discarded).ToList()[1].Source.CompareTo(r23) == 0);
         }
     }
 }

--- a/Core.Tests/SetsAndAttributes/BackgroundPeaks.cs
+++ b/Core.Tests/SetsAndAttributes/BackgroundPeaks.cs
@@ -5,7 +5,7 @@
 using Genometric.GeUtilities.Intervals.Model;
 using Genometric.GeUtilities.Intervals.Parsers.Model;
 using Genometric.MSPC.Core.Model;
-using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -14,9 +14,9 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
     public class BackgroundPeaks
     {
         private readonly string _chr = "chr1";
-        private readonly char _strand = '*';
+        private readonly char _strand = '.';
 
-        private ReadOnlyDictionary<uint, Result<Peak>> GenerateAndProcessBackgroundPeaks()
+        private Dictionary<uint, Result<Peak>> GenerateAndProcessBackgroundPeaks()
         {
             var sA = new Bed<Peak>();
             sA.Add(new Peak(left: 10, right: 20, value: 1e-2), _chr, _strand);
@@ -42,7 +42,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Get(Attributes.Background).Count() == 1);
+                Assert.True(s.Value.Chromosomes[_chr][_strand].Get(Attributes.Background).Count() == 1);
         }
 
         [Fact]
@@ -54,12 +54,12 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
             // Assert
             foreach (var s in res)
                 Assert.True(
-                    !s.Value.Chromosomes[_chr].Get(Attributes.Weak).Any() &&
-                    !s.Value.Chromosomes[_chr].Get(Attributes.Stringent).Any() &&
-                    !s.Value.Chromosomes[_chr].Get(Attributes.Confirmed).Any() &&
-                    !s.Value.Chromosomes[_chr].Get(Attributes.Discarded).Any() &&
-                    !s.Value.Chromosomes[_chr].Get(Attributes.TruePositive).Any() &&
-                    !s.Value.Chromosomes[_chr].Get(Attributes.FalsePositive).Any());
+                    !s.Value.Chromosomes[_chr][_strand].Get(Attributes.Weak).Any() &&
+                    !s.Value.Chromosomes[_chr][_strand].Get(Attributes.Stringent).Any() &&
+                    !s.Value.Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Any() &&
+                    !s.Value.Chromosomes[_chr][_strand].Get(Attributes.Discarded).Any() &&
+                    !s.Value.Chromosomes[_chr][_strand].Get(Attributes.TruePositive).Any() &&
+                    !s.Value.Chromosomes[_chr][_strand].Get(Attributes.FalsePositive).Any());
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
             var res = mspc.Run(config);
 
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Count(Attributes.Background) == 1);
+                Assert.True(s.Value.Chromosomes[_chr][_strand].Count(Attributes.Background) == 1);
         }
 
         [Fact]
@@ -105,8 +105,8 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
             var res = mspc.Run(config);
 
             Assert.True(
-                res[0].Chromosomes[_chr].Count(Attributes.Background) == 1 &&
-                res[1].Chromosomes[_chr].Count(Attributes.Background) == 0);
+                res[0].Chromosomes[_chr][_strand].Count(Attributes.Background) == 1 &&
+                res[1].Chromosomes[_chr][_strand].Count(Attributes.Background) == 0);
         }
 
         [Fact]
@@ -133,8 +133,8 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
             // Assert
 
             Assert.True(
-                res[0].Chromosomes[_chr].Get(Attributes.Background).ToList()[0].Source.Equals(sAP) &&
-                res[1].Chromosomes[_chr].Get(Attributes.Background).ToList()[0].Source.Equals(sBP));
+                res[0].Chromosomes[_chr][_strand].Get(Attributes.Background).ToList()[0].Source.Equals(sAP) &&
+                res[1].Chromosomes[_chr][_strand].Get(Attributes.Background).ToList()[0].Source.Equals(sBP));
         }
     }
 }

--- a/Core.Tests/SetsAndAttributes/Confirmed.cs
+++ b/Core.Tests/SetsAndAttributes/Confirmed.cs
@@ -6,7 +6,7 @@ using Genometric.GeUtilities.Intervals.Model;
 using Genometric.GeUtilities.Intervals.Parsers.Model;
 using Genometric.MSPC.Core.Model;
 using System;
-using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -15,9 +15,9 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
     public class Confirmed
     {
         private readonly string _chr = "chr1";
-        private readonly char _strand = '*';
+        private readonly char _strand = '.';
 
-        private ReadOnlyDictionary<uint, Result<Peak>> CreateStringentPeaksAndConfirmThem()
+        private Dictionary<uint, Result<Peak>> CreateStringentPeaksAndConfirmThem()
         {
             var sA = new Bed<Peak>();
             sA.Add(new Peak(left: 10, right: 20, value: 1e-9), _chr, _strand);
@@ -44,7 +44,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
             // Assert
             foreach (var result in results)
                 Assert.True(
-                    Math.Round(result.Value.Chromosomes[_chr].Get(Attributes.Confirmed).First().XSquared, 8) == 96.70857391);
+                    Math.Round(result.Value.Chromosomes[_chr][_strand].Get(Attributes.Confirmed).First().XSquared, 8) == 96.70857391);
         }
 
         [Fact]
@@ -55,7 +55,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             foreach (var result in results)
-                Assert.True(result.Value.Chromosomes[_chr].Get(Attributes.Confirmed).First().RTP.ToString("E5") == "4.93543E-020");
+                Assert.True(result.Value.Chromosomes[_chr][_strand].Get(Attributes.Confirmed).First().RTP.ToString("E5") == "4.93543E-020");
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Count(Attributes.Confirmed) == 1);
+                Assert.True(s.Value.Chromosomes[_chr][_strand].Count(Attributes.Confirmed) == 1);
         }
 
         [Fact]
@@ -90,7 +90,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Count(Attributes.Confirmed) == 1);
+                Assert.True(s.Value.Chromosomes[_chr][_strand].Count(Attributes.Confirmed) == 1);
         }
 
         [Fact]
@@ -114,7 +114,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Count(Attributes.Confirmed) == 1);
+                Assert.True(s.Value.Chromosomes[_chr][_strand].Count(Attributes.Confirmed) == 1);
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             foreach (var s in res)
-                Assert.False(s.Value.Chromosomes[_chr].Get(Attributes.Discarded).Any());
+                Assert.False(s.Value.Chromosomes[_chr][_strand].Get(Attributes.Discarded).Any());
         }
 
         [Fact]
@@ -152,8 +152,8 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
             // Assert
 
             Assert.True(
-                res[0].Chromosomes[_chr].Get(Attributes.Confirmed).ToList()[0].Source.Equals(sAP) &&
-                res[1].Chromosomes[_chr].Get(Attributes.Confirmed).ToList()[0].Source.Equals(sBP));
+                res[0].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).ToList()[0].Source.Equals(sAP) &&
+                res[1].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).ToList()[0].Source.Equals(sBP));
         }
 
         [Fact]
@@ -178,7 +178,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
             var res = mspc.Run(config);
 
             // Assert
-            Assert.True(res[0].Chromosomes[_chr].Get(Attributes.Confirmed).Any());
+            Assert.True(res[0].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Any());
         }
 
         [Fact]
@@ -204,8 +204,8 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             Assert.True(
-                res[0].Chromosomes[_chr].Get(Attributes.Confirmed).Any() &&
-                res[1].Chromosomes[_chr].Get(Attributes.Confirmed).Any());
+                res[0].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Any() &&
+                res[1].Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Any());
         }
     }
 }

--- a/Core.Tests/SetsAndAttributes/Discarded.cs
+++ b/Core.Tests/SetsAndAttributes/Discarded.cs
@@ -5,7 +5,7 @@
 using Genometric.GeUtilities.Intervals.Model;
 using Genometric.GeUtilities.Intervals.Parsers.Model;
 using Genometric.MSPC.Core.Model;
-using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -14,9 +14,9 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
     public class Discarded
     {
         private readonly string _chr = "chr1";
-        private readonly char _strand = '*';
+        private readonly char _strand = '.';
 
-        private ReadOnlyDictionary<uint, Result<Peak>> CreateStringentPeaksAndDiscardThem()
+        private Dictionary<uint, Result<Peak>> CreateStringentPeaksAndDiscardThem()
         {
             var sA = new Bed<Peak>();
             sA.Add(new Peak(left: 10, right: 20, value: 1e-9), _chr, _strand);
@@ -42,7 +42,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Count(Attributes.Discarded) == 1);
+                Assert.True(s.Value.Chromosomes[_chr][_strand].Count(Attributes.Discarded) == 1);
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Count(Attributes.Discarded) == 1);
+                Assert.True(s.Value.Chromosomes[_chr][_strand].Count(Attributes.Discarded) == 1);
         }
 
         [Fact]
@@ -90,7 +90,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Count(Attributes.Discarded) == 1);
+                Assert.True(s.Value.Chromosomes[_chr][_strand].Count(Attributes.Discarded) == 1);
         }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             foreach (var s in res)
-                Assert.False(s.Value.Chromosomes[_chr].Get(Attributes.Confirmed).Any());
+                Assert.False(s.Value.Chromosomes[_chr][_strand].Get(Attributes.Confirmed).Any());
         }
 
         [Fact]
@@ -128,8 +128,8 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
             // Assert
 
             Assert.True(
-                res[0].Chromosomes[_chr].Get(Attributes.Discarded).ToList()[0].Source.Equals(sAP) &&
-                res[1].Chromosomes[_chr].Get(Attributes.Discarded).ToList()[0].Source.Equals(sBP));
+                res[0].Chromosomes[_chr][_strand].Get(Attributes.Discarded).ToList()[0].Source.Equals(sAP) &&
+                res[1].Chromosomes[_chr][_strand].Get(Attributes.Discarded).ToList()[0].Source.Equals(sBP));
         }
     }
 }

--- a/Core.Tests/SetsAndAttributes/FalsePositive.cs
+++ b/Core.Tests/SetsAndAttributes/FalsePositive.cs
@@ -5,7 +5,7 @@
 using Genometric.GeUtilities.Intervals.Model;
 using Genometric.GeUtilities.Intervals.Parsers.Model;
 using Genometric.MSPC.Core.Model;
-using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -14,9 +14,9 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
     public class FalsePositive
     {
         private readonly string _chr = "chr1";
-        private readonly char _strand = '*';
+        private readonly char _strand = '.';
 
-        private ReadOnlyDictionary<uint, Result<Peak>> GenerateAndProcessBackgroundPeaks()
+        private Dictionary<uint, Result<Peak>> GenerateAndProcessBackgroundPeaks()
         {
             var sA = new Bed<Peak>();
             sA.Add(new Peak(left: 10, right: 20, value: 1e-6), _chr, _strand);
@@ -41,7 +41,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
             var res = GenerateAndProcessBackgroundPeaks();
 
             // Assert
-            Assert.True(res[0].Chromosomes[_chr].Count(Attributes.FalsePositive) == 1);
+            Assert.True(res[0].Chromosomes[_chr][_strand].Count(Attributes.FalsePositive) == 1);
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             foreach (var sample in res)
-                Assert.True(sample.Value.Chromosomes[_chr].Count(Attributes.FalsePositive) == 2);
+                Assert.True(sample.Value.Chromosomes[_chr][_strand].Count(Attributes.FalsePositive) == 2);
         }
 
         [Fact]
@@ -99,7 +99,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
             var res = mspc.Run(config);
 
             // Assert
-            Assert.True(res[0].Chromosomes[_chr].Get(Attributes.FalsePositive).First().Source.Equals(r11));
+            Assert.True(res[0].Chromosomes[_chr][_strand].Get(Attributes.FalsePositive).First().Source.Equals(r11));
         }
 
         [Fact]
@@ -128,7 +128,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             foreach (var sample in res)
-                Assert.True(sample.Value.Chromosomes[_chr].Count(Attributes.FalsePositive) == 4);
+                Assert.True(sample.Value.Chromosomes[_chr][_strand].Count(Attributes.FalsePositive) == 4);
         }
     }
 }

--- a/Core.Tests/SetsAndAttributes/Stringent.cs
+++ b/Core.Tests/SetsAndAttributes/Stringent.cs
@@ -5,7 +5,7 @@
 using Genometric.GeUtilities.Intervals.Model;
 using Genometric.GeUtilities.Intervals.Parsers.Model;
 using Genometric.MSPC.Core.Model;
-using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -14,9 +14,9 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
     public class Stringent
     {
         private readonly string _chr = "chr1";
-        private readonly char _strand = '*';
+        private readonly char _strand = '.';
 
-        private ReadOnlyDictionary<uint, Result<Peak>> GenerateAndProcessStringentPeaks()
+        private Dictionary<uint, Result<Peak>> GenerateAndProcessStringentPeaks()
         {
             var sA = new Bed<Peak>();
             sA.Add(new Peak(left: 10, right: 20, value: 1e-9), _chr, _strand);
@@ -42,7 +42,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Count(Attributes.Stringent) == 1);
+                Assert.True(s.Value.Chromosomes[_chr][_strand].Count(Attributes.Stringent) == 1);
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             foreach (var s in res)
-                Assert.False(s.Value.Chromosomes[_chr].Get(Attributes.Weak).Any());
+                Assert.False(s.Value.Chromosomes[_chr][_strand].Get(Attributes.Weak).Any());
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             foreach (var s in res)
-                Assert.False(s.Value.Chromosomes[_chr].Get(Attributes.Background).Any());
+                Assert.False(s.Value.Chromosomes[_chr][_strand].Get(Attributes.Background).Any());
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Count(Attributes.Stringent) == 1);
+                Assert.True(s.Value.Chromosomes[_chr][_strand].Count(Attributes.Stringent) == 1);
         }
 
         [Fact]
@@ -115,8 +115,8 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
             // Assert
 
             Assert.True(
-                res[0].Chromosomes[_chr].Get(Attributes.Stringent).ToList()[0].Source.Equals(sAP) &&
-                res[1].Chromosomes[_chr].Get(Attributes.Stringent).ToList()[0].Source.Equals(sBP));
+                res[0].Chromosomes[_chr][_strand].Get(Attributes.Stringent).ToList()[0].Source.Equals(sAP) &&
+                res[1].Chromosomes[_chr][_strand].Get(Attributes.Stringent).ToList()[0].Source.Equals(sBP));
         }
     }
 }

--- a/Core.Tests/SetsAndAttributes/TruePositive.cs
+++ b/Core.Tests/SetsAndAttributes/TruePositive.cs
@@ -15,7 +15,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
     public class TruePositive
     {
         private readonly string _chr = "chr1";
-        private readonly char _strand = '*';
+        private readonly char _strand = '.';
 
         private readonly string[] _chrs = new string[] { "chr1", "chr1", "chr5", "chrx" };
 
@@ -54,7 +54,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
             return mspc;
         }
 
-        private ReadOnlyDictionary<uint, Result<Peak>> GetResults(int peakCount = 4, float alpha = 5e-10F)
+        private Dictionary<uint, Result<Peak>> GetResults(int peakCount = 4, float alpha = 5e-10F)
         {
             return SetupMSPC(peakCount, alpha).GetResults();
         }
@@ -66,7 +66,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
             var res = GetResults(peakCount: 1, alpha: 5e-7F);
 
             // Assert
-            Assert.True(res[1].Chromosomes[_chr].Count(Attributes.TruePositive) == 1);
+            Assert.True(res[1].Chromosomes[_chr][_strand].Count(Attributes.TruePositive) == 1);
         }
 
         [Fact]
@@ -80,7 +80,8 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
             {
                 int count = 0;
                 foreach (var chr in sample.Value.Chromosomes)
-                    count += chr.Value.Count(Attributes.TruePositive);
+                    foreach (var strand in chr.Value)
+                        count += strand.Value.Count(Attributes.TruePositive);
 
                 Assert.True(count == 2);
             }
@@ -93,7 +94,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
             var results = GetResults();
 
             // Assert
-            Assert.True(results[0].Chromosomes[_chrs[2]].Get(Attributes.TruePositive).First().Source.Equals(_setA[2]));
+            Assert.True(results[0].Chromosomes[_chrs[2]][_strand].Get(Attributes.TruePositive).First().Source.Equals(_setA[2]));
         }
 
         [Fact]
@@ -107,7 +108,8 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
             {
                 int count = 0;
                 foreach (var chr in sample.Value.Chromosomes)
-                    count += chr.Value.Count(Attributes.TruePositive);
+                    foreach (var strand in chr.Value)
+                        count += strand.Value.Count(Attributes.TruePositive);
 
                 Assert.True(count == 4);
             }

--- a/Core.Tests/SetsAndAttributes/Weak.cs
+++ b/Core.Tests/SetsAndAttributes/Weak.cs
@@ -5,7 +5,7 @@
 using Genometric.GeUtilities.Intervals.Model;
 using Genometric.GeUtilities.Intervals.Parsers.Model;
 using Genometric.MSPC.Core.Model;
-using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -14,9 +14,9 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
     public class Weak
     {
         private readonly string _chr = "chr1";
-        private readonly char _strand = '*';
+        private readonly char _strand = '.';
 
-        private ReadOnlyDictionary<uint, Result<Peak>> GenerateAndProcessWeakPeaks()
+        private Dictionary<uint, Result<Peak>> GenerateAndProcessWeakPeaks()
         {
             var sA = new Bed<Peak>();
             sA.Add(new Peak(left: 10, right: 20, value: 1e-5, summit: 15, name: "peak"), _chr, _strand);
@@ -42,7 +42,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Count(Attributes.Weak) == 1);
+                Assert.True(s.Value.Chromosomes[_chr][_strand].Count(Attributes.Weak) == 1);
         }
 
         [Fact]
@@ -53,7 +53,9 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             foreach (var s in res)
-                Assert.False(s.Value.Chromosomes[_chr].Get(Attributes.Stringent).Any());
+
+
+                Assert.False(s.Value.Chromosomes[_chr][_strand].Get(Attributes.Stringent).Any());
         }
 
         [Fact]
@@ -64,7 +66,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             foreach (var s in res)
-                Assert.False(s.Value.Chromosomes[_chr].Get(Attributes.Background).Any());
+                Assert.False(s.Value.Chromosomes[_chr][_strand].Get(Attributes.Background).Any());
         }
 
         [Fact]
@@ -88,7 +90,7 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
 
             // Assert
             foreach (var s in res)
-                Assert.True(s.Value.Chromosomes[_chr].Count(Attributes.Weak) == 1);
+                Assert.True(s.Value.Chromosomes[_chr][_strand].Count(Attributes.Weak) == 1);
         }
 
         [Fact]
@@ -115,8 +117,8 @@ namespace Genometric.MSPC.Core.Tests.SetsAndAttributes
             // Assert
 
             Assert.True(
-                res[0].Chromosomes[_chr].Get(Attributes.Weak).ToList()[0].Source.Equals(sAP) &&
-                res[1].Chromosomes[_chr].Get(Attributes.Weak).ToList()[0].Source.Equals(sBP));
+                res[0].Chromosomes[_chr][_strand].Get(Attributes.Weak).ToList()[0].Source.Equals(sAP) &&
+                res[1].Chromosomes[_chr][_strand].Get(Attributes.Weak).ToList()[0].Source.Equals(sBP));
         }
     }
 }

--- a/Core/Functions/FalseDiscoveryRate.cs
+++ b/Core/Functions/FalseDiscoveryRate.cs
@@ -33,22 +33,24 @@ namespace Genometric.MSPC.Core.Functions
                 });
         }
 
-        private List<ProcessedPeak<I>> UnionChrs(ConcurrentDictionary<string, Sets<I>> chrs)
+        private List<ProcessedPeak<I>> UnionChrs(ConcurrentDictionary<string, ConcurrentDictionary<char, Sets<I>>> chrs)
         {
             IEnumerable<ProcessedPeak<I>> peaks = new List<ProcessedPeak<I>>();
             foreach (var chr in chrs)
-                peaks = peaks.Union(chr.Value.Get(Attributes.Confirmed));
+                foreach (var strand in chr.Value)
+                    peaks = peaks.Union(strand.Value.Get(Attributes.Confirmed));
             return peaks.ToList();
         }
 
         /// <summary>
         /// Benjamini–Hochberg (step-up) procedure.
         /// </summary>
-        public void PerformMultipleTestingCorrection(Dictionary<string, List<ProcessedPeak<I>>> peaks, float alpha)
+        public void PerformMultipleTestingCorrection(Dictionary<string, Dictionary<char, List<ProcessedPeak<I>>>> peaks, float alpha)
         {
             IEnumerable<ProcessedPeak<I>> ps = new List<ProcessedPeak<I>>();
             foreach (var chr in peaks)
-                ps = ps.Union(chr.Value);
+                foreach (var strand in chr.Value)
+                    ps = ps.Union(strand.Value);
             PerformMultipleTestingCorrection(ps.ToList(), alpha);
         }
 

--- a/Core/Model/Result.cs
+++ b/Core/Model/Result.cs
@@ -11,17 +11,22 @@ namespace Genometric.MSPC.Core.Model
         where I : IPeak
     {
         private readonly ReplicateType _replicateType;
-        public ConcurrentDictionary<string, Sets<I>> Chromosomes { set; get; }
+        public ConcurrentDictionary<string, ConcurrentDictionary<char, Sets<I>>> Chromosomes { set; get; }
 
         internal Result(ReplicateType replicateType)
         {
             _replicateType = replicateType;
-            Chromosomes = new ConcurrentDictionary<string, Sets<I>>();
+            Chromosomes = new ConcurrentDictionary<string, ConcurrentDictionary<char, Sets<I>>>();
         }
 
-        public void AddChromosome(string chr, int capacity)
+        public void AddChromosome(string chr)
         {
-            Chromosomes.TryAdd(chr, new Sets<I>(capacity, _replicateType));
+            Chromosomes.TryAdd(chr, new ConcurrentDictionary<char, Sets<I>>());
+        }
+
+        public void AddStrand(string chr, char strand, int capacity)
+        {
+            Chromosomes[chr].TryAdd(strand, new Sets<I>(capacity, _replicateType));
         }
     }
 }

--- a/Core/MspcGeneric.cs
+++ b/Core/MspcGeneric.cs
@@ -29,7 +29,7 @@ namespace Genometric.MSPC.Core
         private Processor<I> _processor { set; get; }
         private BackgroundWorker _backgroundProcessor { set; get; }
 
-        private ReadOnlyDictionary<uint, Result<I>> _results { set; get; }
+        private Dictionary<uint, Result<I>> _results { set; get; }
 
         public int? DegreeOfParallelism
         {
@@ -60,7 +60,7 @@ namespace Genometric.MSPC.Core
             _processor.AddSample(id, sample);
         }
 
-        public ReadOnlyDictionary<uint, Result<I>> Run(Config config)
+        public Dictionary<uint, Result<I>> Run(Config config)
         {
             if (_processor.SamplesCount < 2)
                 throw new InvalidOperationException(string.Format("Minimum two samples are required; {0} is given.", _processor.SamplesCount));
@@ -92,12 +92,12 @@ namespace Genometric.MSPC.Core
             Canceled.Reset();
         }
 
-        public ReadOnlyDictionary<uint, Result<I>> GetResults()
+        public Dictionary<uint, Result<I>> GetResults()
         {
             return _results;
         }
 
-        public ReadOnlyDictionary<string, List<ProcessedPeak<I>>> GetConsensusPeaks()
+        public Dictionary<string, Dictionary<char, List<ProcessedPeak<I>>>> GetConsensusPeaks()
         {
             return _processor.ConsensusPeaks;
         }

--- a/website/docs/cli/args.md
+++ b/website/docs/cli/args.md
@@ -67,6 +67,12 @@ $ dotnet mspc.dll -i *.bed -r bio -w 1e-4 -s 1e-8
 $ dotnet mspc.dll -i C:\setA\*.bed -i C:\setB\sci-ATAC*.bed -r bio -w 1e-4 -s 1e-8
 ```
 
+:::info
+By default, MSPC reads input files unstranded, if your
+data are stranded, you may [adjust the parser](parser) accordingly.
+
+:::
+
 ### Replicate Type
 Samples could be biological or technical replicates. MSPC differentiates between 
 the two replicate types based on the fact that less variations between technical 

--- a/website/docs/cli/input.md
+++ b/website/docs/cli/input.md
@@ -5,15 +5,32 @@ title: Input
 MSPC takes as input a tab-delimited file in 
 [BED format]( https://uswest.ensembl.org/info/website/upload/bed.html) for each replicate, 
 each containing enriched regions (aka peaks) called with a permissive p-value threshold. 
-
 By default, the columns of the BED files should comply the following field order:
 
-| Index | Name       |
-|-------|------------|
-| 0     | chrom      |
-| 1     | chromStart |
-| 2     | chromEnd   |
-| 3     | name       |
-| 4     | value      |
 
-The p-value needs to be in `-Log10(p-value)` format. More columns can be present, but they will not be parsed.
+| Chrome | Start  | End | Name | Value |
+|--------|--------|-----|------|-------|
+
+The p-value needs to be in `-Log10(p-value)` format. More columns 
+can be present, but they will not be parsed.
+
+
+For instance:
+
+```
+chrome	start	end		name	value
+chr1	1000	2000	peak_1	11
+chr1	3000	4000	peak_2	22
+chr1	5000	6000	peak_3	33
+```
+
+:::info
+* If your files are not in this format, you may configure MSPC's parser 
+[according to your files](parser.md).
+
+* If you files are stranded, you would need to [adjust the parser](parser.md)
+ accordingly, otherwise, MSPC will read 
+them un-stranded.
+:::
+
+

--- a/website/docs/cli/output.md
+++ b/website/docs/cli/output.md
@@ -79,20 +79,20 @@ in a `Confirmed.bed` and `Discarded.bed` files may read is the following:
 
 ```
 $ head .\rep1\Confirmed.bed
-chr     start   stop    name    -1xlog10(p-value)
-chr1    32600   32680   MACS_peak_4     4.08
-chr1    32726   32936   MACS_peak_5     17.5
-chr1    34689   34797   MACS_peak_6     5.82
-chr1    35083   35124   MACS_peak_7     4.59
-chr1    38593   38836   MACS_peak_8     10.7
+chr     start   stop    name     -1xlog10(p-value)	strand
+chr1    32600   32680   peak_4   4.08	            .
+chr1    32726   32936   peak_5   17.5	            .
+chr1    34689   34797   peak_6   5.82	            .
+chr1    35083   35124   peak_7   4.59	            .
+chr1    38593   38836   peak_8   10.7	            .
 
 $ head .\rep1\Discarded.bed
-chr     start   stop    name    -1xlog10(p-value)
-chr1    137343  137383  MACS_peak_10    4.8
-chr1    228585  228625  MACS_peak_12    4.37
-chr1    265059  265115  MACS_peak_14    5.22
-chr1    557793  557833  MACS_peak_29    4.16
-chr1    725914  725963  MACS_peak_34    5.95
+chr     start   stop    name     -1xlog10(p-value)	strand
+chr1    137343  137383  peak_10  4.8	            .
+chr1    228585  228625  peak_12  4.37	            .
+chr1    265059  265115  peak_14  5.22	            .
+chr1    557793  557833  peak_29  4.16	            .
+chr1    725914  725963  peak_34  5.95	            .
 ``` 
 
 Accordingly, the peak named `MACS_peak_4 ` is _confirmed_ while 
@@ -120,20 +120,20 @@ peaks in the confirmed and discarded sets are as the following.
 
 ```
 $ head .\rep1\Confirmed_mspc_peaks.txt
-chr     start   stop    name    -1xlog10(p-value)       xSqrd   -1xlog10(Right-Tail Probability)        -1xlog10(AdjustedP-value)
-chr1    32600   32680   MACS_peak_4     4.08    222.936 46.359  4.07
-chr1    32726   32936   MACS_peak_5     17.5    284.738 59.674  16.146
-chr1    34689   34797   MACS_peak_6     5.82    74.005  14.49   5.634
-chr1    35083   35124   MACS_peak_7     4.59    52.867  10.042  4.537
-chr1    38593   38836   MACS_peak_8     10.7    121.576 24.609  9.892
+chr     start   stop    name	  -1xlog10(p-value)  strand  xSqrd	  -1xlog10(Right-Tail Probability)  -1xlog10(AdjustedP-value)
+chr1    32600   32680   peak_4    4.08               .       222.936  46.359                            4.07
+chr1    32726   32936   peak_5    17.5               .       284.738  59.674                            16.146
+chr1    34689   34797   peak_6    5.82               .       74.005   14.49                             5.634
+chr1    35083   35124   peak_7    4.59               .       52.867   10.042                            4.537
+chr1    38593   38836   peak_8    10.7               .       121.576  24.609                            9.892
 
 $ head .\rep1\Discarded_mspc_peaks.txt
-chr     start   stop    name    -1xlog10(p-value)       xSqrd   -1xlog10(Right-Tail Probability)        -1xlog10(AdjustedP-value)
-chr1    137343  137383  MACS_peak_10    4.8     22.105  4.8     NaN
-chr1    228585  228625  MACS_peak_12    4.37    20.125  4.37    NaN
-chr1    265059  265115  MACS_peak_14    5.22    24.039  5.22    NaN
-chr1    557793  557833  MACS_peak_29    4.16    19.158  4.16    NaN
-chr1    725914  725963  MACS_peak_34    5.95    27.401  5.95    NaN
+chr     start   stop    name	  -1xlog10(p-value)  strand  xSqrd   -1xlog10(Right-Tail Probability)  -1xlog10(AdjustedP-value)
+chr1    137343  137383  peak_10   4.8                .       22.105  4.8                               NaN
+chr1    228585  228625  peak_12   4.37               .       20.125  4.37                              NaN
+chr1    265059  265115  peak_14   5.22               .       24.039  5.22                              NaN
+chr1    557793  557833  peak_29   4.16               .       19.158  4.16                              NaN
+chr1    725914  725963  peak_34   5.95               .       27.401  5.95                              NaN
 ```
 
 Note that the first five columns are identical between `*.bed` 

--- a/website/docs/cli/parser.md
+++ b/website/docs/cli/parser.md
@@ -19,7 +19,7 @@ chr1	35083	35124	MACS_peak_7	4.59
 ```
 
 The fifth column represents the p-value, and by default, MSPC expects
-it be in `-Log10` format (read [how to adjust this configuration](#p-value-format). 
+it be in `-Log10` format (read [how to adjust this configuration](#p-value-format)). 
 Also, by default, MSPC expects each peak 
 to have a p-value; otherwise, that peak will not be parsed into MSPC.
 
@@ -38,9 +38,9 @@ in the following sections.
    "Left":1,
    "Right":2,
    "Name":3,
-   "Strand":4,
-   "Summit":5,
-   "Value":6,
+   "Value":4,
+   "Strand":-1,
+   "Summit":-1,
    "Culture":"en-US",
    "PValueFormat":1,
    "DefaultValue":0.0001,
@@ -59,25 +59,32 @@ requiring the users to convert them to a common format, MSPC allows
 users to configure its parser by specifying the number of columns
 that contain required information.
 
-To specify column order, create a plain text file with the 
-following content: 
 
-```json
-{  
-   "Chr":0,
-   "Left":1,
-   "Right":2,
-   "Strand":4,
-   "Name":3,
-   "Value":4,
-   "Summit":5
-}
+For instance, if your samples are stranded, you may 
+configure the parser as the following. 
+
+```
+chr1	633859	634162	peak_1	137	.
+chr1	1079427	1079669	peak_2	67	.
+chr1	1109848	1110187	peak_3	91	.
 ```
 
-Change the values of each configuration key according 
-to your BED file. Then save this file with any name 
-(e.g., `myConfig.json`), and give its path to MSPC 
-using [`--parser` argument](cli/args.md#input-parser-configuration).
+Create a JSON file as the following:
+
+```json
+{"Strand": 5}
+```
+
+and execute MSPC as the following passing the 
+[parser configuration](args#input-parser-configuration) :
+
+```shell
+mspc.exe -i inputs*.bed -r bio -w 1e-4 -s 1e-8 -p parser_config.json
+```
+
+where `parser_config.json` is the filename of the file
+containing the JSON object you created above.
+
 
 ## p-Value Format
 


### PR DESCRIPTION
Addresses https://github.com/Genometric/MSPC/issues/165

- [x] If the strand is not given in the input, it treats all the reads unstranded and reports `.` as the strand of the peaks in the output;
- [x] If the input peaks have strand, it processes the peaks stranded (i.e., peaks on the `+` strand are processed independent from those on the strand `-`);
- [x] By default it will parse strand from the 4th column (zero-based), [which can be changed](https://genometric.github.io/MSPC/docs/cli/parser);
- [x] All the tests are updated to assert the changes, and related tests are added;
- [ ] Update docs.  