### PR TITLE
Extend tests asserting if peaks on all chrs and strands are exported

### DIFF
--- a/CLI.Tests/Main.cs
+++ b/CLI.Tests/Main.cs
@@ -262,11 +262,28 @@ namespace Genometric.MSPC.CLI.Tests
 
             // Assert
             Assert.Contains("All processes successfully finished", output);
+            string[] columns;
             using (var reader = new StreamReader(Directory.GetFiles(outputPath, "*ConsensusPeaks.bed")[0]))
             {
                 Assert.Equal("chr\tstart\tstop\tname\t-1xlog10(p-value)\tstrand", reader.ReadLine());
-                Assert.Equal("chr1\t4\t20\tMSPC_Peak_1\t25.219\t.", reader.ReadLine());
-                Assert.Equal("chr2\t25\t45\tMSPC_Peak_2\t12.97\t.", reader.ReadLine());
+
+                columns = reader.ReadLine().Split('\t');
+                Assert.True(
+                    columns[0] == "chr1" && 
+                    columns[1] == "4" && 
+                    columns[2] == "20" && 
+                    columns[3].StartsWith("MSPC_Peak_") && 
+                    columns[4] == "25.219" && 
+                    columns[5] == ".");
+
+                columns = reader.ReadLine().Split('\t');
+                Assert.True(
+                    columns[0] == "chr2" &&
+                    columns[1] == "25" &&
+                    columns[2] == "45" &&
+                    columns[3].StartsWith("MSPC_Peak_") &&
+                    columns[4] == "12.97" &&
+                    columns[5] == ".");
                 Assert.Null(reader.ReadLine());
             }
 
@@ -274,14 +291,28 @@ namespace Genometric.MSPC.CLI.Tests
             Assert.True(dirs.Length == 2);
 
             Assert.True(Directory.GetFiles(dirs[0]).Length == 14);
-            string line;
             using (var reader = new StreamReader(Directory.GetFiles(dirs[0], "*TruePositive.bed")[0]))
             {
                 Assert.Equal("chr\tstart\tstop\tname\t-1xlog10(p-value)\tstrand", reader.ReadLine());
-                line = reader.ReadLine();
-                Assert.True("chr1\t10\t20\tmspc_peak_1\t7.12\t." == line || "chr1\t4\t12\tmspc_peak_3\t19.9\t." == line);
-                line = reader.ReadLine();
-                Assert.True("chr2\t25\t35\tmspc_peak_2\t5.507\t." == line || "chr2\t30\t45\tmspc_peak_4\t9\t." == line);
+
+                columns = reader.ReadLine().Split('\t');
+                Assert.True(
+                    columns[0] == "chr1" &&
+                    (columns[1] == "10" || columns[1] == "4") &&
+                    (columns[2] == "20" || columns[2] == "12") &&
+                    columns[3].ToLower().StartsWith("mspc_peak_") &&
+                    (columns[4] == "7.12" || columns[4] == "19.9") &&
+                    columns[5] == ".");
+
+                columns = reader.ReadLine().Split('\t');
+                Assert.True(
+                    columns[0] == "chr2" &&
+                    (columns[1] == "25" || columns[1] == "30") &&
+                    (columns[2] == "35" || columns[2] == "45") &&
+                    columns[3].ToLower().StartsWith("mspc_peak_") &&
+                    (columns[4] == "5.507" || columns[4] == "9") &&
+                    columns[5] == ".");
+
                 Assert.Null(reader.ReadLine());
             }
 
@@ -290,10 +321,25 @@ namespace Genometric.MSPC.CLI.Tests
             using (var reader = new StreamReader(Directory.GetFiles(dirs[1], "*TruePositive.bed")[0]))
             {
                 Assert.Equal("chr\tstart\tstop\tname\t-1xlog10(p-value)\tstrand", reader.ReadLine());
-                line = reader.ReadLine();
-                Assert.True("chr1\t10\t20\tmspc_peak_1\t7.12\t." == line || "chr1\t4\t12\tmspc_peak_3\t19.9\t." == line);
-                line = reader.ReadLine();
-                Assert.True("chr2\t25\t35\tmspc_peak_2\t5.507\t." == line || "chr2\t30\t45\tmspc_peak_4\t9\t." == line);
+
+                columns = reader.ReadLine().Split('\t');
+                Assert.True(
+                    columns[0] == "chr1" &&
+                    (columns[1] == "10" || columns[1] == "4") &&
+                    (columns[2] == "20" || columns[2] == "12") &&
+                    columns[3].ToLower().StartsWith("mspc_peak_") &&
+                    (columns[4] == "7.12" || columns[4] == "19.9") &&
+                    columns[5] == ".");
+
+                columns = reader.ReadLine().Split('\t');
+                Assert.True(
+                    columns[0] == "chr2" &&
+                    (columns[1] == "25" || columns[1] == "30") &&
+                    (columns[2] == "35" || columns[2] == "45") &&
+                    columns[3].ToLower().StartsWith("mspc_peak_") &&
+                    (columns[4] == "5.507" || columns[4] == "9") &&
+                    columns[5] == ".");
+
                 Assert.Null(reader.ReadLine());
             }
 

--- a/CLI.Tests/Main.cs
+++ b/CLI.Tests/Main.cs
@@ -64,7 +64,7 @@ namespace Genometric.MSPC.CLI.Tests
 
                 pValue = 5.5067;
                 writter.WriteLine(
-                    "chr1\t25\t35\tmspc_peak_2\t" +
+                    "chr2\t25\t35\tmspc_peak_2\t" +
                     pValue.ToString(CultureInfo.CreateSpecificCulture(culture)));
             }
 
@@ -78,7 +78,7 @@ namespace Genometric.MSPC.CLI.Tests
 
                 pValue = 8.999999;
                 writter.WriteLine(
-                    "chr1\t30\t45\tmspc_peak_4\t" +
+                    "chr2\t30\t45\tmspc_peak_4\t" +
                     pValue.ToString(CultureInfo.CreateSpecificCulture(culture)));
             }
         }
@@ -265,8 +265,8 @@ namespace Genometric.MSPC.CLI.Tests
             using (var reader = new StreamReader(Directory.GetFiles(outputPath, "*ConsensusPeaks.bed")[0]))
             {
                 Assert.Equal("chr\tstart\tstop\tname\t-1xlog10(p-value)\tstrand", reader.ReadLine());
-                Assert.Equal("chr1\t4\t20\tMSPC_Peak_2\t25.219\t.", reader.ReadLine());
-                Assert.Equal("chr1\t25\t45\tMSPC_Peak_1\t12.97\t.", reader.ReadLine());
+                Assert.Equal("chr1\t4\t20\tMSPC_Peak_1\t25.219\t.", reader.ReadLine());
+                Assert.Equal("chr2\t25\t45\tMSPC_Peak_2\t12.97\t.", reader.ReadLine());
                 Assert.Null(reader.ReadLine());
             }
 
@@ -281,7 +281,7 @@ namespace Genometric.MSPC.CLI.Tests
                 line = reader.ReadLine();
                 Assert.True("chr1\t10\t20\tmspc_peak_1\t7.12\t." == line || "chr1\t4\t12\tmspc_peak_3\t19.9\t." == line);
                 line = reader.ReadLine();
-                Assert.True("chr1\t25\t35\tmspc_peak_2\t5.507\t." == line || "chr1\t30\t45\tmspc_peak_4\t9\t." == line);
+                Assert.True("chr2\t25\t35\tmspc_peak_2\t5.507\t." == line || "chr2\t30\t45\tmspc_peak_4\t9\t." == line);
                 Assert.Null(reader.ReadLine());
             }
 
@@ -293,7 +293,7 @@ namespace Genometric.MSPC.CLI.Tests
                 line = reader.ReadLine();
                 Assert.True("chr1\t10\t20\tmspc_peak_1\t7.12\t." == line || "chr1\t4\t12\tmspc_peak_3\t19.9\t." == line);
                 line = reader.ReadLine();
-                Assert.True("chr1\t25\t35\tmspc_peak_2\t5.507\t." == line || "chr1\t30\t45\tmspc_peak_4\t9\t." == line);
+                Assert.True("chr2\t25\t35\tmspc_peak_2\t5.507\t." == line || "chr2\t30\t45\tmspc_peak_4\t9\t." == line);
                 Assert.Null(reader.ReadLine());
             }
 

--- a/Core.Tests/Basic/TConsensusPeaks.cs
+++ b/Core.Tests/Basic/TConsensusPeaks.cs
@@ -142,5 +142,38 @@ namespace Genometric.MSPC.Core.Tests.Basic
             Assert.True(r3.HasAttribute(Attributes.TruePositive));
             Assert.True(r4.HasAttribute(Attributes.FalsePositive));
         }
+
+        [Fact]
+        public void ReportAllChrsAndStrands()
+        {
+            // Arrange
+            var s0 = new Bed<Peak>();
+            s0.Add(new Peak(10, 20, 1.23E-8), "chr1", '+');
+            s0.Add(new Peak(50, 60, 1.56E-80), "chr2", '-');
+
+            var s1 = new Bed<Peak>();
+            s1.Add(new Peak(6, 16, 4.56E-8), "chr1", '+');
+            s1.Add(new Peak(70, 80, 8.76E-9), "chr3", '-');
+
+            var s2 = new Bed<Peak>();
+            s2.Add(new Peak(2, 26, 7.89E-10), "chr1", '+');
+            s2.Add(new Peak(50, 60, 9.9E-20), "chr2", '-');
+            s2.Add(new Peak(76, 90, 1.1E-8), "chr3", '+');
+
+            var mspc = new Mspc();
+            mspc.AddSample(0, s0);
+            mspc.AddSample(1, s1);
+            mspc.AddSample(2, s2);
+
+            // Act
+            mspc.Run(new Config(ReplicateType.Biological, 1E-4, 1E-6, 1E-6, 1, 0.05f, MultipleIntersections.UseLowestPValue));
+            var consensusPeaks = mspc.GetConsensusPeaks();
+
+            // Assert
+            Assert.True(consensusPeaks.Count == 3);
+            Assert.True(consensusPeaks["chr1"].Count == 1);
+            Assert.True(consensusPeaks["chr2"].Count == 1);
+            Assert.True(consensusPeaks["chr3"].Count == 2);
+        }
     }
 }


### PR DESCRIPTION
A few tests are added and updated to assert if peaks on different chromosomes and strands are all exported.